### PR TITLE
Feature/selection area

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
-        "checkJs": true
+        "checkJs": true,
+        "target": "es5"
     },
     "exclude": [
         "node_modules",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6874,6 +6874,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
+      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "dev": true
+    },
     "eslint-plugin-security": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-1.4.0.tgz",

--- a/src/modules/_createSelector.js
+++ b/src/modules/_createSelector.js
@@ -3,10 +3,9 @@ import '../types.js'
 /**
  * Create the selector node when not provided by options object.
  * @param {boolean} customStyles
- * @param {DSArea} area
  * @return {HTMLElement}
  */
-export default (customStyles, area) => {
+export default (customStyles) => {
   const selector = document.createElement('div')
 
   selector.style.position = 'absolute'
@@ -16,9 +15,6 @@ export default (customStyles, area) => {
     selector.style.display = 'none'
     selector.style.pointerEvents = 'none' // fix for issue #8 (ie11+)
   }
-
-  const _area = area === document ? document.body : area
-  _area.appendChild(selector)
 
   return selector
 }

--- a/src/modules/_getComputedBorder.js
+++ b/src/modules/_getComputedBorder.js
@@ -4,7 +4,12 @@ import '../types.js'
  * @param {DSArea} area
  */
 export default area => {
-  if (area instanceof HTMLDocument) return 0
+  if (area instanceof HTMLDocument) return { top: 0, bottom: 0, left: 0, right: 0 }
   const computedStyles = getComputedStyle(area)
-  return parseInt(computedStyles.borderWidth) || 0
+  return { 
+    top: parseInt(computedStyles.borderTopWidth) || 0,
+    bottom: parseInt(computedStyles.borderBottomWidth) || 0,
+    left: parseInt(computedStyles.borderLeftWidth) || 0,
+    right: parseInt(computedStyles.borderRightWidth) || 0
+  }
 }

--- a/src/modules/_getSelectorPosition.js
+++ b/src/modules/_getSelectorPosition.js
@@ -22,7 +22,7 @@ export default (area, zoom, initialScroll, initialCursorPos, event) => {
 
   /** check for direction
    *
-   * This is quite complicated math, so also quite complicated to explain. Lemme’ try:
+   * This is quite complicated, so also quite complicated to explain. Lemme’ try:
    *
    * Problem #1:
    * Sadly in HTML we can not have negative sizes.
@@ -43,19 +43,16 @@ export default (area, zoom, initialScroll, initialCursorPos, event) => {
    * checks we have to subtract 10px from the initialcursor position in our check
    * (since the initial position is moved to the left by 10px) so in our example:
    * 1. cursorPosNew.x (5) > initialCursorPos.x (0) - scrollAmount.x (10) === 5 > -10 === true
-   * then reset the x position to its initial position (since we might have changed that
-   * position when scrolling to the left before going right) in our example:
-   * 2. selectorPos.x = initialCursorPos.x (0) + initialScroll.x (0) === 0;
+   * then set the x position to the cursors start position
+   * selectorPos.x = initialCursorPos.x (0) - scrollAmount.x (10) === 10 // 2.
    * then we can calculate the elements width, which is
    * the new cursor position minus the initial one plus the scroll amount, so in our example:
    * 3. selectorPos.w = cursorPosNew.x (5) - initialCursorPos.x (0) + scrollAmount.x (10) === 15;
    *
    * let’s say after that movement we now scroll 20px to the left and move our cursor by 30px to the left:
-   * 1b. cursorPosNew.x (-30) > initialCursorPos.x (0) - scrollAmount.x (-20) === -30 > -20 === false;
-   * 2b. selectorPos.x = cursorPosNew.x (-30) + scrollNew.x (-20)
-   *                   === -50;  // move left position to cursor (for more info see Problem #1)
-   * 3b. selectorPos.w = initialCursorPos.x (0) - cursorPosNew.x (-30) - scrollAmount.x (-20)
-   *                   === 0--30--20 === 0+30+20 === 50;  // scale width to original left position (for more info see Problem #1)
+   * 1b. cursorPosNew.x (-30) > initialCursorPos.x (0) - scrollAmount.x (-20) === -30 < --20 === -30 < +20 === false;
+   * 2b. selectorPos.x = cursorPosNew.x (-30) === -30; move left position to cursor (for more info see Problem #1)
+   * 3b. selectorPos.w = initialCursorPos.x (0) - cursorPosNew.x (-30) - scrollAmount.x (-20) === 0--30--20 === 0+30+20 === 50;  // scale width to original left position (for more info see Problem #1)
    *
    * same thing has to be done for top/bottom
    *
@@ -64,24 +61,22 @@ export default (area, zoom, initialScroll, initialCursorPos, event) => {
   const selectorPos = {}
 
   // right
-  if (cursorPosNew.x > initialCursorPos.x - scrollAmount.x) {
-    // 1.
-    selectorPos.x = initialCursorPos.x + initialScroll.x // 2.
+  if (cursorPosNew.x > initialCursorPos.x - scrollAmount.x) { // 1.
+    selectorPos.x = initialCursorPos.x - scrollAmount.x // 2.
     selectorPos.w = cursorPosNew.x - initialCursorPos.x + scrollAmount.x // 3.
     // left
-  } else {
-    // 1b.
-    selectorPos.x = cursorPosNew.x + scrollNew.x // 2b.
+  } else { // 1b.
+    selectorPos.x = cursorPosNew.x // 2b.
     selectorPos.w = initialCursorPos.x - cursorPosNew.x - scrollAmount.x // 3b.
   }
 
   // bottom
   if (cursorPosNew.y > initialCursorPos.y - scrollAmount.y) {
-    selectorPos.y = initialCursorPos.y + initialScroll.y
+    selectorPos.y = initialCursorPos.y - scrollAmount.y
     selectorPos.h = cursorPosNew.y - initialCursorPos.y + scrollAmount.y
     // top
   } else {
-    selectorPos.y = cursorPosNew.y + scrollNew.y
+    selectorPos.y = cursorPosNew.y
     selectorPos.h = initialCursorPos.y - cursorPosNew.y - scrollAmount.y
   }
 

--- a/src/modules/_isScrollbarClick.js
+++ b/src/modules/_isScrollbarClick.js
@@ -14,7 +14,7 @@ export default (area, zoom, event) => {
   const areaRect = _getAreaRect(area)
   const border = _getComputedBorder(area)
 
-  if (areaRect.width + border <= cPos.x) return true
-  if (areaRect.height + border <= cPos.y) return true
+  if (areaRect.width + border.left + border.right <= cPos.x) return true
+  if (areaRect.height + border.top + border.bottom <= cPos.y) return true
   return false
 }

--- a/src/modules/_selectorArea.js
+++ b/src/modules/_selectorArea.js
@@ -1,0 +1,65 @@
+import '../types.js'
+import { _getAreaRect, _getComputedBorder } from './'
+
+/**
+ * Creates the SelectorArea
+ * @return {HTMLElement}
+ */
+export const create = () => {
+  const selectorArea = document.createElement('div')
+  selectorArea.style.position = 'fixed'
+  selectorArea.style.overflow = 'hidden'
+  selectorArea.style.pointerEvents = 'none'
+  return selectorArea
+}
+
+/**
+ * @param {HTMLElement} selectorArea
+ * @param {DSArea} area
+ * @return {function}
+ */
+const modificationEvent = (selectorArea, area) => (event) => updatePosition(selectorArea, area)
+
+/** @type {*} */
+let modificationCallback
+/** @type {MutationObserver} */
+let modificationObserver
+
+/**
+ * Adds event-listeners to the selectorArea
+ * @param {HTMLElement} selectorArea
+ * @param {DSArea} area
+ */
+export const addObservers = (selectorArea, area) => {
+  modificationCallback = modificationEvent(selectorArea, area)
+  window.addEventListener('resize', modificationCallback)
+  window.addEventListener('scroll', modificationCallback)
+  modificationObserver = new MutationObserver(modificationCallback);
+  modificationObserver.observe(document.body, { subtree: true, childList: true, attributes: true });
+  modificationObserver.observe(area, { attributes: true, });
+}
+
+/**
+ * Removes event-listeners to the selectorArea
+ */
+export const removeObservers = () => {
+  window.removeEventListener('resize', modificationCallback)
+  window.removeEventListener('scroll', modificationCallback)
+  modificationObserver.disconnect()
+}
+
+/**
+ * Updates the selectorAreas positions to match the areas
+ * @param {HTMLElement} selectorArea
+ * @param {DSArea} area
+ * @return {HTMLElement}
+ */
+export const updatePosition = (selectorArea, area) => {
+  const rect = _getAreaRect(area)
+  const border = _getComputedBorder(area)
+  selectorArea.style.top = `${rect.top + border.top}px`
+  selectorArea.style.left = `${rect.left + border.left}px`
+  selectorArea.style.width = `${rect.width}px`
+  selectorArea.style.height = `${rect.height}px`
+  return selectorArea
+}

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,3 +1,4 @@
+export * as _selectorArea from './_selectorArea'
 export { default as _autoScroll } from './_autoScroll'
 export { default as _createSelector } from './_createSelector'
 export { default as _getAreaRect } from './_getAreaRect'

--- a/src/modules/isCursorNearEdge.js
+++ b/src/modules/isCursorNearEdge.js
@@ -15,8 +15,8 @@ export default (area, zoom, event) => {
   const areaRect = _getAreaRect(area)
 
   const tolerance = {
-    x: Math.max(areaRect.width / 10, 30),
-    y: Math.max(areaRect.height / 10, 30),
+    x: 5,
+    y: 5,
   }
 
   if (cursorPosition.y < tolerance.y) return 'top'


### PR DESCRIPTION
# add selection area
- selector is not inside of the area itself (solves #63)
- selector is now in a fresh selection area overlay (solves #26)
- the overlay adapts size to always match the real area
- the overlay has no pointer-events and acts as a clip box
- selection can be drawn outside of the area
which makes autoscrolling and selection easier

# Comparision
## Before
![before](https://user-images.githubusercontent.com/12467511/98852906-ac37eb80-2458-11eb-9197-d224473957f0.gif)

## After
![after](https://user-images.githubusercontent.com/12467511/98852954-beb22500-2458-11eb-8cbc-23568ff8ffc4.gif)
