### PR TITLE
fix(#90): correct the behavior of `modules/SelectableSet.removeSelectables` method

### DIFF
--- a/src/DragSelect.js
+++ b/src/DragSelect.js
@@ -431,8 +431,8 @@ class DragSelect {
    * @return {DSInputElements} the removed element(s)
    */
   removeSelectables(elements, removeFromSelection = false) {
-    this.SelectedSet.clear()
-    if (removeFromSelection) this.SelectedSet.clear()
+    this.SelectableSet.deleteAll(toArray(elements))
+    if (removeFromSelection) this.removeSelection(elements)
     return elements
   }
   /** The starting/initial position of the cursor/selector @return {Vect2} */


### PR DESCRIPTION
fix(#90): correct the behavior of `modules/SelectableSet.removeSelectables` method

1. it should remove selectable elements.
2. it should remove the elements user pass in.