### PR TITLE
Feature/add ts docs #93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Next release
 
 - Fixes bug #83: keyboard dragging is not disabled when draggability is disabled
+- Adds typescript support by adding types files to dist as specified in issue #93
+- Un-track dist file
 
 # 2.0.3
 

--- a/__tests__/functional/imports.spec.js
+++ b/__tests__/functional/imports.spec.js
@@ -1,6 +1,6 @@
-const { beforeAll, afterAll, it } = require('@jest/globals')
-const http = require('http')
-const fs = require('fs')
+import wait from '../helpers/wait'
+import http from 'http'
+import fs from 'fs'
 
 const baseUrl = `file://${process.cwd()}/__tests__/functional`
 
@@ -156,6 +156,7 @@ describe('Imports', () => {
 
   describe('ESM Module', () => {
     const setup = async (uri = '../../dist/DragSelect.es6m.js') => {
+      await wait(500)
       await page.evaluate((uri) => {
         window.dsScript = document.createElement('script')
         window.dsScript.setAttribute('type', 'module')
@@ -165,8 +166,12 @@ describe('Imports', () => {
           window.ds.subscribe('callback', ({ items }) => (window.callback = items.map((item) => item.id)))
           `
         document.body.appendChild(window.dsScript)
-        window.importScripts.push(window.dsScript)
+        setTimeout(() => {
+          if (!window.importScripts) window.importScripts = []
+          window.importScripts.push(window.dsScript)
+        }, 500)
       }, uri)
+      await wait(500)
     }
 
     it('when importing the script as module, it should be available', async () => {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "rm": "rm -rf dist docs",
     "prerollup": "npm run types",
     "rollup": "rollup -c",
-    "rollup:travis": "rollup -c --travis",
+    "rollup:travis": "npm run rollup -- --travis",
     "rollup:watch": "npm run rollup -- -w",
     "test": "npm run checkjs && jest --detectOpenHandles",
     "test:watch": "jest --watch",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "travis:test": "npm run rollup && npm run test"
   },
   "devDependencies": {
-    "ds": "dist/DragSelect.js",
     "@babel/cli": "^7.12.10",
     "@babel/compat-data": "^7.12.7",
     "@babel/core": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "postcheckjs": "npm run docs && rm -rf docs",
     "checkjs": "tsc --lib es2019,dom -t es5 --allowJs --checkJs --noEmit src/*.js",
     "checkjs:watch": "tsc -w --lib es2019,dom -t es5 --allowJs --checkJs --noEmit src/*.js",
+    "types": "tsc src/**/*.js --lib es2019,dom -t es5 --declaration --allowJs --emitDeclarationOnly --outDir dist",
     "docs": "jsdoc -c jsdoc.json",
     "media": "cp -R .media docs/media",
     "premedia": "rm -r docs/media &",
     "rm": "rm -rf dist docs",
+    "prerollup": "npm run types",
     "rollup": "rollup -c",
     "rollup:travis": "rollup -c --travis",
     "rollup:watch": "npm run rollup -- -w",
@@ -24,6 +26,7 @@
     "travis:test": "npm run rollup && npm run test"
   },
   "devDependencies": {
+    "ds": "dist/DragSelect.js",
     "@babel/cli": "^7.12.10",
     "@babel/compat-data": "^7.12.7",
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
This PR adds typescript support by generating TS files in build in the dist folder.
Those should be available via NPM and provide enhanced type support for library users.

This will fix #93 