### PR TITLE
remove selector elements on stop

### DIFF
--- a/__tests__/functional/stop.spec.js
+++ b/__tests__/functional/stop.spec.js
@@ -20,9 +20,9 @@ describe('Stop', () => {
     await mouse.move(50, 50)
     await mouse.up()
 
-    var callback = await page.evaluate(() => callback)
+    let callback = await page.evaluate(() => callback)
     expect(callback.length).toBe(1)
-    var callback = await page.evaluate(() => (callback = []))
+    callback = await page.evaluate(() => (callback = []))
 
     await page.evaluate(() => ds.stop())
     await mouse.move(10, 10)
@@ -30,8 +30,12 @@ describe('Stop', () => {
     await mouse.move(50, 50)
     await mouse.up()
 
-    var callback = await page.evaluate(() => callback)
+    callback = await page.evaluate(() => callback)
     expect(callback.length).toBe(0)
+    const dragNode = await page.$('.ds-selector')
+    expect(dragNode).toBeNull()
+    const areaNode = await page.$('.ds-selector-area')
+    expect(areaNode).toBeNull()
   })
 
   it('should stop the functionality in a callback', async () => {

--- a/src/DragSelect.js
+++ b/src/DragSelect.js
@@ -262,7 +262,7 @@ class DragSelect {
     this.Area.stop()
     this.Drag.stop()
     this.Selector.stop()
-    this.SelectorArea.stop()
+    this.SelectorArea.stop(remove)
     this.stores.KeyStore.stop()
     this.stores.PointerStore.stop()
     this.stores.ScrollStore.stop()
@@ -272,7 +272,7 @@ class DragSelect {
   }
   /**
    * Utility to override DragSelect internal functionality:
-   * Break will skip the selection or dragging functionality but let everything continue to run until after the callback.
+   * Break will skip the selection or dragging functionality (until after the callback) but let everything continue to run.
    * Useful utility to write your own functionality/move/dragNdrop based on DragSelect pointer positions.
    */
   break = () => (this.continue = true)

--- a/src/modules/SelectorArea.js
+++ b/src/modules/SelectorArea.js
@@ -47,16 +47,27 @@ export default class SelectorArea {
     this.DS = DS
 
     this.HTMLNode = createSelectorAreaElement(selectorAreaClass)
-    this.HTMLNode.appendChild(this.DS.Selector.HTMLNode)
-    const docEl = document.body ? 'body' : 'documentElement'
-    document[docEl].appendChild(this.HTMLNode)
 
     this.DS.subscribe('Area:modified', this.updatePos)
+    this.DS.subscribe('Interaction:init', this.start)
     this.DS.subscribe('Interaction:start', this.startAutoScroll)
     this.DS.subscribe('Interaction:end', () => {
       this.updatePos()
       this.stopAutoScroll()
     })
+  }
+
+  start = () => this.applyElements('append')
+
+  /**
+   * Adding / Removing elements to document
+   * @param {'append'|'remove'} method
+   */
+  applyElements = (method = 'append') => {
+    const docEl = document.body ? 'body' : 'documentElement'
+    const methodName = `${method}Child`
+    this.HTMLNode[methodName](this.DS.Selector.HTMLNode)
+    document[docEl][methodName](this.HTMLNode)
   }
 
   /** Updates the selectorAreas positions to match the areas */
@@ -75,7 +86,10 @@ export default class SelectorArea {
     if (style.height !== height) style.height = height
   }
 
-  stop = () => this.stopAutoScroll()
+  stop = (remove) => {
+    this.stopAutoScroll()
+    if (remove) this.applyElements('remove')
+  }
 
   //////////////////////////////////////////////////////////////////////////////////////
   // AutoScroll


### PR DESCRIPTION
- removes dom-nodes when using `.stop`
- fixes #94 