### PR TITLE
Add support for pointerEvents

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ ds.subscribe('predragmove', ({ isDragging, isDraggingKeyboard }) => {
 |hoverClass |string |The class name assigned to the mouse hovered items. |[see classes](#classes)
 |selectorClass |string |The class name assigned to the square selector helper. |[see classes](#classes)
 |selectableClass |string |The class name assigned to the elements that can be selected. |[see classes](#classes)
+|usePointerEvents |boolean |Whether to use Pointer Events to replace traditional Mouse or Touch Events. |`false`
 
 # Event Callbacks
 

--- a/__tests__/functional/multiselection.spec.js
+++ b/__tests__/functional/multiselection.spec.js
@@ -52,7 +52,7 @@ describe('Multiselection', () => {
     await wait(100)
 
     const { multiselected } = await page.evaluate(() => ({ multiselected }))
-    const expected = ['one2', 'three2', 'four2', 'five2']
+    const expected = ['two2', 'three2', 'four2', 'five2']
     expect(multiselected.sort()).toEqual(expected.sort())
   })
 

--- a/src/DragSelect.js
+++ b/src/DragSelect.js
@@ -99,6 +99,7 @@ class DragSelect {
     onDragStart,
     onElementSelect,
     onElementUnselect,
+    usePointerEvents = false,
   }) {
     this.PubSub = new PubSub({ DS: this })
     this.subscribe = this.PubSub.subscribe
@@ -114,7 +115,7 @@ class DragSelect {
     })
 
     this.stores = {
-      PointerStore: new PointerStore({ DS: this }),
+      PointerStore: new PointerStore({ DS: this, usePointerEvents }),
       ScrollStore: new ScrollStore({ DS: this, areaElement: area, zoom }),
       KeyStore: new KeyStore({ DS: this, multiSelectKeys, multiSelectMode }),
     }
@@ -142,6 +143,7 @@ class DragSelect {
       hoverClassName: hoverClass,
       useTransform,
       draggability,
+      usePointerEvents,
     })
 
     this.SelectedSet = new SelectedSet({
@@ -179,6 +181,7 @@ class DragSelect {
       draggability,
       immediateDrag,
       selectableClass,
+      usePointerEvents,
     })
 
     // Subscriber Aliases

--- a/src/methods/getPointerPos.js
+++ b/src/methods/getPointerPos.js
@@ -4,7 +4,7 @@ import '../types'
 /**
  * Returns cursor x, y position based on event object
  * @param {Object} p
- * @param {MouseEvent|Touch} p.event
+ * @param {MouseEvent|Touch|PointerEvent} p.event
  * @return {Vect2} cursor X/Y position
  */
 export default ({ event }) => ({

--- a/src/modules/SelectableSet.js
+++ b/src/modules/SelectableSet.js
@@ -30,6 +30,11 @@ export default class SelectableSet extends Set {
    * @private
    * */
   _draggability
+    /**
+   * @type {boolean}
+   * @private
+   * */
+  _usePointerEvents
 
   /**
    * @constructor SelectableSet
@@ -40,6 +45,7 @@ export default class SelectableSet extends Set {
    * @param {string} p.hoverClassName
    * @param {boolean} p.useTransform
    * @param {boolean} p.draggability
+   * @param {boolean} p.usePointerEvents
    * @ignore
    */
   constructor({
@@ -47,6 +53,7 @@ export default class SelectableSet extends Set {
     className,
     hoverClassName,
     draggability,
+    usePointerEvents,
     useTransform,
     DS,
   }) {
@@ -57,6 +64,7 @@ export default class SelectableSet extends Set {
     this._hoverClassName = hoverClassName
     this._useTransform = useTransform
     this._draggability = draggability
+    this._usePointerEvents = usePointerEvents
 
     this.DS.subscribe('Interaction:init', this.init)
   }
@@ -67,7 +75,14 @@ export default class SelectableSet extends Set {
   add(element) {
     element.classList.add(this._className)
     element.addEventListener('click', this._onClick)
-    element.addEventListener('mousedown', this._onPointer)
+    if (this._usePointerEvents) {
+      element.addEventListener('pointerdown', this._onPointer, {
+        // @ts-ignore
+        passive: false,
+      })
+    } else {
+      element.addEventListener('mousedown', this._onPointer)
+    }
     element.addEventListener('touchstart', this._onPointer, {
       // @ts-ignore
       passive: false,
@@ -87,7 +102,14 @@ export default class SelectableSet extends Set {
     element.classList.remove(this._className)
     element.classList.remove(this._hoverClassName)
     element.removeEventListener('click', this._onClick)
-    element.removeEventListener('mousedown', this._onPointer)
+    if (this._usePointerEvents) {
+      element.removeEventListener('pointerdown', this._onPointer, {
+        // @ts-ignore
+        passive: false,
+      })
+    } else {
+      element.removeEventListener('mousedown', this._onPointer)
+    }
     element.removeEventListener('touchstart', this._onPointer, {
       // @ts-ignore
       passive: false,

--- a/src/stores/KeyStore.js
+++ b/src/stores/KeyStore.js
@@ -90,7 +90,7 @@ export default class KeyStore {
 
   reset = () => this._currentValues.clear()
 
-  /** @param {KeyboardEvent|MouseEvent|TouchEvent} [event] */
+  /** @param {KeyboardEvent|MouseEvent|PointerEvent|TouchEvent} [event] */
   isMultiSelectKeyPressed(event) {
     if (this._multiSelectMode) return true
     if (this.currentValues.some((key) => this._multiSelectKeys.includes(key)))

--- a/src/stores/PointerStore.js
+++ b/src/stores/PointerStore.js
@@ -46,20 +46,34 @@ export default class PointerStore {
   _lastTouch
 
   /**
+   * @type {boolean}
+   * @private
+   * */
+  _usePointerEvents
+
+  /**
    * @class PointerStore
    * @constructor PointerStore
-   * @param {{DS:DragSelect}} p
+   * @param {{DS:DragSelect,usePointerEvents:boolean}} p
    * @ignore
    */
-  constructor({ DS }) {
+  constructor({ DS, usePointerEvents = false }) {
     this.DS = DS
+    this._usePointerEvents = usePointerEvents
     this.DS.subscribe('Interaction:init', this.init)
     this.DS.subscribe('Interaction:start', ({ event }) => this.start(event))
     this.DS.subscribe('Interaction:end', ({ event }) => this.reset(event))
   }
 
   init = () => {
-    document.addEventListener('mousemove', this.update)
+    if (this._usePointerEvents) {
+      document.addEventListener('pointermove', this.update, {
+        // @ts-ignore
+        passive: false,
+      })
+    } else {
+      document.addEventListener('mousemove', this.update)
+    }
     document.addEventListener('touchmove', this.update, {
       // @ts-ignore
       passive: false,
@@ -89,7 +103,14 @@ export default class PointerStore {
   }
 
   stop = () => {
-    document.removeEventListener('mousemove', this.update)
+    if (this._usePointerEvents) {
+      document.removeEventListener('pointermove', this.update, {
+        // @ts-ignore
+        passive: false,
+      })
+    } else {
+      document.removeEventListener('mousemove', this.update)
+    }
     document.removeEventListener('touchmove', this.update, {
       // @ts-ignore
       passive: false,
@@ -110,7 +131,7 @@ export default class PointerStore {
 
   /**
    * @param {DSEvent} event
-   * @return {MouseEvent|Touch}
+   * @return {MouseEvent|PointerEvent|Touch}
    * @private
    */
   _normalizedEvent(event) {

--- a/src/types.js
+++ b/src/types.js
@@ -28,13 +28,14 @@
  * @property {DSCallback} [onDragStart] Deprecated: please use DragSelect.subscribe('onDragStart', onDragStart) instead
  * @property {DSCallback} [onElementSelect] Deprecated: please use DragSelect.subscribe('onElementSelect', onElementSelect) instead
  * @property {DSCallback} [onElementUnselect] Deprecated: please use DragSelect.subscribe('onElementUnselect', onElementUnselect) instead
+ * @property {boolean} [usePointerEvents=false] Whether to use Pointer Events to replace traditional Mouse or Touch Events.
  */
 
 /**
  * The Object that is passed back to any callback method
  * @typedef {Object} CallbackObject
  * @property {Array<HTMLElement|SVGElement|any>} [items] The items currently selected
- * @property {MouseEvent|TouchEvent|KeyboardEvent|Event} [event] The respective event object
+ * @property {MouseEvent|TouchEvent|PointerEvent|KeyboardEvent|Event} [event] The respective event object
  * @property {HTMLElement|SVGElement|any} [item] The single item currently interacted with
  * @property {boolean} [isDragging] Whether the interaction is a drag or a select
  * @property {boolean} [isDraggingKeyboard] Whether or not the drag interaction is via keyboard
@@ -56,7 +57,7 @@
 /** @typedef {Array.<HTMLElement|SVGElement> | HTMLElement | SVGElement} DSInputElements the elements that can be selected */
 /** @typedef {Array.<HTMLElement|SVGElement>} DSElements the elements that can be selected */
 /** @typedef {HTMLElement|SVGElement} DSElement a single element that can be selected */
-/** @typedef {MouseEvent|TouchEvent} DSEvent en event from a touch or mouse interaction */
+/** @typedef {MouseEvent|TouchEvent|PointerEvent} DSEvent en event from a touch or mouse interaction */
 /** @typedef {Array.<'Shift'|'Control'|'Meta'|string>} DSMultiSelectKeys An array of keys that allows switching to the multi-select mode */
 
 /** @typedef {'dragmove'|'autoscroll'|'dragstart'|'elementselect'|'elementunselect'|'callback'} DSEventNames */


### PR DESCRIPTION
Hi, thanks for this great library. I'm now preparing to use DragSelect for implementing [Google Blockly](https://github.com/google/blockly)'s [multiselection project](https://summerofcode.withgoogle.com/programs/2022/projects/9wF06HWE). However, DragSelect can't work on Blockly as of now, Google Blockly uses the pointerEvents:

https://github.com/google/blockly/blob/24a808d54eef1711801ff3b7e6082409a8a78666/core/browser_events.js#L95-L100
https://github.com/google/blockly/blob/master/core/touch.js#L58-L69

So this PR makes DragSelect also listen to the pointerEvents so that it can work for the Blockly. It would be great if this PR can get merged and a new release can be drafted for this. Thank you!