### PR TITLE
Feature/111 change props dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.4.0
+
+- Change all Properties dynamically *anytime*. Solves #111 and #95. Very helpful for async libraries like react. You can do so using the `setSettings` method, you can pass any settings in the object and they will be updated. Example: update the drag area at any time by running: `ds.setSettings({ area: document.getElementById("new-area") })`.
+- Remove deprecated keys `ctrlKey`, `shiftKey` and `metaKey`. Use `Control`, `Shift` and `Meta` respectively instead.
+- Remove deprecated method `getCursorPositionDifference`. Calculate the difference on your own instead.
+- Remove deprecated setting property callbacks. Use `DragSelect.subscribe("callback", (callbackObject) => {})` instead.
+
 # 2.3.1
 
 - Fix bug [#109](https://github.com/ThibaultJanBeyer/DragSelect/issues/109) where inner elements are ignored from normal drag behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.4.0
+# Next
 
 - Change all Properties dynamically *anytime*. Solves #111 and #95. Very helpful for async libraries like react. You can do so using the `setSettings` method, you can pass any settings in the object and they will be updated. Example: update the drag area at any time by running: `ds.setSettings({ area: document.getElementById("new-area") })`.
 - Remove deprecated keys `ctrlKey`, `shiftKey` and `metaKey`. Use `Control`, `Shift` and `Meta` respectively instead.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ easily add a selection algorithm to your application/website.
 - - [Mobile Touch usage](#mobiletouch-usage)
 - - [Accessibility (a11y)](#accessibility-a11y)
 - - [Use your own Drag And Drop](#use-your-own-drag-and-drop)
-- [Constructor Properties](#constructor-properties)
+- [Constructor Properties (Settings)](#constructor-properties-settings)
+- - [Post initialization setting updates](#post-initialization-setting-updates)
 - [Event Callbacks](#event-callbacks)
 - - [Callback Object Keys](#callback-object-keys)
 - [Methods](#methods)
@@ -153,26 +154,24 @@ All options are optional. You could also just initiate the Dragselect by `new Dr
 Find all possible properties and methods in **[the docs](https://dragselect.com/DragSelect.html)**  
 
 ```javascript
+// if you add the function to a variable like this, you have access to all its functions
 const ds = new DragSelect({
-  // node/nodes that can be selected.
-  // This is also optional, you could just add them later with .addSelectables().
+  // all settings are optional and can be added later
+});
+
+// this is how you add/update settings after initialization
+ds.setSettings({
+  // node/nodes that can be selected. By default will never add elements twice:
   selectables: document.querySelectorAll('.selectable-nodes'),
   // area in which you can drag. If not provided it will be the whole document & body/documentElement.
   area: document.getElementById('area'),
   // and many more, see "properties" section in the docs
-});
-
-// if you add the function to a variable like we did, you have access to all its functions:
+})
 
 // fired once the user releases the mouse. (items) = selected nodes:
 ds.subscribe('callback', ({ items, event }) => {})
-
 // returns all currently selected nodes:
 ds.getSelection();
-
-// adds elements that can be selected. Won't add elements twice:
-ds.addSelectables(document.getElementsByClassName('selectable-node'));
-
 // Teardown/stop the whole functionality:
 ds.stop();
 // Reset the functionality after a teardown:
@@ -260,9 +259,13 @@ ds.subscribe('predragmove', ({ isDragging, isDraggingKeyboard }) => {
 }
 ```
 
-# Constructor Properties:
+# Constructor Properties (Settings):
 
-*DragSelect is hyper customizable*. Note, all properties are optional. See **[the docs](https://dragselect.com/DragSelect.html)** for more info. Here is the full list:  
+*DragSelect is hyper customizable*. Note, all properties are optional. See **[the docs](https://dragselect.com/DragSelect.html)** for more info.  
+
+Moreover any setting can also be updated or added after the initialization, see [post-initialization setting updates](#post-initialization-setting-updates).
+
+Here is the full list:  
 
 | property | type | usage | default |
 |--- |--- |--- |--- |
@@ -286,6 +289,18 @@ ds.subscribe('predragmove', ({ isDragging, isDraggingKeyboard }) => {
 |hoverClass |string |The class name assigned to the mouse hovered items. |[see classes](#classes)
 |selectorClass |string |The class name assigned to the square selector helper. |[see classes](#classes)
 |selectableClass |string |The class name assigned to the elements that can be selected. |[see classes](#classes)
+
+## Post-Initialization Setting-Updates
+
+Any setting can be updated/added after initialization by using the `setSettings` method. Here is an example updating the `area` and the `selectables`:
+
+```JavaScript
+const ds = new DragSelect({})
+ds.setSettings({
+  selectables: document.getElementsByClassName('selectable-nodes'),
+  area: document.getElementById('area')
+})
+```
 
 # Event Callbacks
 

--- a/__tests__/functional/basics.css
+++ b/__tests__/functional/basics.css
@@ -17,3 +17,14 @@ html, body {
   color: black;
   font-weight: bold;
 }
+
+.container {
+  width: 300px;
+  height: 300px;
+  background: rgba(0, 0, 0, 0.05);
+  border: 5px solid red;
+  position: absolute;
+  overflow: auto;
+  top: 50px;
+  left: 50px;
+}

--- a/__tests__/functional/callbacks.html
+++ b/__tests__/functional/callbacks.html
@@ -46,19 +46,8 @@
 
 <script src="../../dist/DragSelect.js"></script>
 <script>
-    window.onDragStartCalls = [];
-    window.onDragMoveCalls = [];
-    window.onElementSelectCalls = [];
-    window.onElementUnselectCalls = [];
-    window.callbackCalls = [];
-
     const ds = new DragSelect({
         selectables: document.querySelectorAll('.item'),
-        onDragStart: e => window.onDragStartCalls.push({element: e}),
-        onDragMove: e => window.onDragMoveCalls.push({element: e}),
-        onElementSelect: e => window.onElementSelectCalls.push({element: e}),
-        onElementUnselect: e => window.onElementUnselectCalls.push({element: e}),
-        callback: (n, e) => window.callbackCalls.push({elements: n, event: e})
     });
 
     window.pubsub = {}

--- a/__tests__/functional/callbacks.spec.js
+++ b/__tests__/functional/callbacks.spec.js
@@ -6,8 +6,8 @@ describe('Callbacks', () => {
     await page.goto(`${baseUrl}/callbacks.html`)
 
     const mouse = page.mouse
-    // move to the middle of the page
-    await mouse.move(1, 1, { steps: 100 })
+    // move to the beginning of the page
+    await mouse.move(1, 1, { steps: 10 })
     await mouse.down()
     await wait(100)
     // move 200px down and to the end of the page
@@ -19,12 +19,6 @@ describe('Callbacks', () => {
     const executesFn = await page.evaluate(() => {
       ds.Area.scroll(['right'], 1)
       return {
-        onDragStartCalls: window.onDragStartCalls,
-        onDragMoveCalls: window.onDragMoveCalls,
-        onElementSelectCalls: window.onElementSelectCalls,
-        onElementUnselectCalls: window.onElementUnselectCalls,
-        callbackCalls: window.callbackCalls,
-
         onPreDragStartCallsPS: window.pubsub.onPreDragStartCalls,
         onDragStartCallsPS: window.pubsub.onDragStartCalls,
         onDragMoveCallsPS: window.pubsub.onDragMoveCalls,
@@ -34,13 +28,6 @@ describe('Callbacks', () => {
         autoScrollCallsPS: window.pubsub.autoScrollCalls,
       }
     })
-
-    expect(executesFn.onDragStartCalls.length).toBe(1)
-    expect(executesFn.onDragMoveCalls.length).toBe(100)
-    expect(executesFn.onElementSelectCalls.length).toBe(2)
-    expect(executesFn.onElementUnselectCalls.length).toBe(0)
-    expect(executesFn.callbackCalls.length).toBe(1)
-    expect(executesFn.callbackCalls[0].elements.length).toBe(2)
 
     expect(executesFn.onPreDragStartCallsPS.length).toBe(1)
     expect(executesFn.onPreDragStartCallsPS[0].isDragging).toBe(false)

--- a/__tests__/functional/cursor-position-difference.spec.js
+++ b/__tests__/functional/cursor-position-difference.spec.js
@@ -1,4 +1,3 @@
-// Check if onStart ::: getCursorPositionDifference(true) and onMove ::: getCursorPositionDifference() return the correct values
 const baseUrl = `file://${process.cwd()}/__tests__/functional`;
 
 const startPos = 10;

--- a/__tests__/functional/multiselection.spec.js
+++ b/__tests__/functional/multiselection.spec.js
@@ -34,19 +34,19 @@ describe('Multiselection', () => {
     await page.goto(`${baseUrl}/multiselection.html`)
 
     const mouse = page.mouse
-    await mouse.move(1, 1)
+    await mouse.move(1, 80, { steps: 10 })
     await mouse.down()
-    await mouse.move(100, 90, { steps: 10 })
+    await mouse.move(100, 100, { steps: 10 })
     await mouse.up()
     await wait(100)
 
-    await mouse.move(60, 90, { steps: 10 })
+    await mouse.move(60, 80, { steps: 10 })
     await mouse.down()
     await mouse.move(200, 100, { steps: 10 })
     await mouse.up()
     await wait(100)
 
-    await mouse.move(250, 100)
+    await mouse.move(250, 100, { steps: 10 })
     await mouse.down()
     await mouse.up()
     await wait(100)

--- a/__tests__/functional/settings.html
+++ b/__tests__/functional/settings.html
@@ -1,0 +1,42 @@
+<link rel="stylesheet" href="basics.css">
+<style>
+.container2 {
+    top: 400px;
+}
+
+.five {
+    position: absolute;
+    top: 500px;
+}
+</style>
+
+<div class="container">
+    <button type="button" id="one" class="item one">1</button>
+    <button type="button" id="two" class="item two">2</button>
+    <button type="button" id="_five" class="item five">5</button>
+</div>
+
+<div class="container container2">
+    <button type="button" id="three" class="item three">3</button>
+    <button type="button" id="four" class="item four">4</button>
+    <button type="button" id="five" class="item five">5</button>
+</div>
+
+<script src="../../dist/DragSelect.js"></script>
+<script>
+    window.callback = []
+
+    window.ds = new DragSelect({
+        selectables: document.getElementsByClassName('item'),
+        selectorClass: 'selectorrr',
+        draggability: false,
+        immediateDrag: false,
+        keyboardDrag: false,
+        area: document.getElementsByClassName('container')[0],
+    });
+
+    window.ds.subscribe('callback', ({items}) => {
+        console.log(items)
+        window.callback = items.map(item => item.id)
+    })
+</script>

--- a/__tests__/functional/settings.spec.js
+++ b/__tests__/functional/settings.spec.js
@@ -1,0 +1,255 @@
+import wait from '../helpers/wait'
+const baseUrl = `file://${process.cwd()}/__tests__/functional`
+
+const select = async (mouse, x, y) => {
+  await mouse.move(x, y)
+  await mouse.down()
+  await mouse.up()
+}
+
+const selectItems = async (mouse, x, y) => {
+  await wait(100)
+  await mouse.move(x, y)
+  await wait(100)
+  await mouse.down()
+  await wait(100)
+  await mouse.move(5, 5)
+  await wait(100)
+  await mouse.up()
+  await wait(100)
+  const retr = await page.evaluate(() => window.callback)
+  await wait(100)
+  return retr
+}
+
+const moveItem = async (mouse, x, y) => {
+  await mouse.move(x, y)
+  await mouse.down()
+  await mouse.move(x + 200, y + 200, { steps: 10 })
+  await mouse.up()
+}
+
+const moveItemKey = async (mouse, keyboard, x, y, key) => {
+  await mouse.move(x, y)
+  await mouse.down()
+  await mouse.up()
+  await keyboard.press(key)
+  await keyboard.press(key)
+}
+
+describe('Settings', () => {
+  it('area swapping should work', async () => {
+    await page.goto(`${baseUrl}/settings.html`)
+    let cb
+
+    // can select elements in the container 1
+    cb = await selectItems(page.mouse, 180, 120)
+    expect(cb?.sort()).toMatchObject(["one", "two"])
+    await select(page.mouse, 180, 120)
+
+    // can NOT select elements in the container 2
+    cb = await selectItems(page.mouse, 180, 480)
+    expect(cb).toMatchObject([])
+
+    // swap swop
+    await page.evaluate(() => ds.setSettings({
+      area: document.getElementsByClassName('container')[1],
+      selectables: document.getElementsByClassName('four'),
+    }))
+
+    // can NOT select elements in the container 1
+    cb = await selectItems(page.mouse, 180, 120)
+    expect(cb).toMatchObject([])
+
+    // can select elements in the container 2
+    cb = await selectItems(page.mouse, 180, 480)
+    expect(cb).toMatchObject(["four"])
+    await select(page.mouse, 180, 120)
+  })
+
+  it('classes swapping should work', async () => {
+    await page.goto(`${baseUrl}/settings.html`)
+
+    await page.evaluate(() => ds.setSettings({
+      hoverClass: 'class-a',
+      selectableClass: 'class-b',
+      selectedClass: 'class-c',
+      selectorClass: 'class-d',
+      selectorAreaClass: 'class-e',
+    }))
+
+    await wait(100)
+
+    expect(await page.evaluate(() =>
+      document.querySelector('.class-b')
+      && document.querySelector('.class-d')
+      && document.querySelector('.class-e'))).toBeTruthy()
+      
+      await selectItems(page.mouse, 180, 120)
+    
+    expect(await page.evaluate(() =>
+      document.querySelector('.class-c')
+      && document.querySelector('.class-a'))).toBeTruthy()
+  })
+
+  it('zoom swapping should work', async () => {
+    await page.goto(`${baseUrl}/settings.html`)
+    await page.evaluate(() => ds.setSettings({ zoom: 5 }))
+    await wait(100)
+    expect(await page.evaluate(() => ds.stores.SettingsStore.s.zoom)).toEqual(5)
+  })
+
+  it('custom styles swapping should work', async () => {
+    await page.goto(`${baseUrl}/settings.html`)
+    expect(await page.evaluate(() => document.querySelector('.selectorrr').style.background)).toEqual('rgba(0, 0, 255, 0.1)')
+    await page.evaluate(() => ds.setSettings({ customStyles: true, selector: null }))
+    await wait(100)
+    expect(await page.evaluate(() => document.querySelector('.selectorrr').style.background)).toEqual('')
+  })
+
+  it('draggability swapping should work', async () => {
+    await page.goto(`${baseUrl}/settings.html`)
+    let cb
+    cb = await selectItems(page.mouse, 180, 120)
+    expect(cb?.sort()).toMatchObject(["one", "two"])
+    await page.evaluate(() => ds.setSettings({ draggability: false }))
+    // move with draggability OFF
+    await moveItem(page.mouse, 140, 85)
+    cb = await selectItems(page.mouse, 180, 120)
+    expect(cb?.sort()).toMatchObject(["one", "two"])
+    // move with draggability ON
+    await page.evaluate(() => ds.setSettings({ draggability: true }))
+    await moveItem(page.mouse, 140, 85)
+    cb = await selectItems(page.mouse, 180, 120)
+    expect(cb?.sort()).toMatchObject([])
+  })
+
+  it('immediatedrag swapping should work', async () => {
+    await page.goto(`${baseUrl}/settings.html`)
+    let cb
+    await page.evaluate(() => ds.setSettings({ draggability: true }))
+    await moveItem(page.mouse, 140, 85)
+    await select(page.mouse, 180, 120)
+    cb = await selectItems(page.mouse, 140, 85)
+    expect(cb?.sort()).toMatchObject(["one", "two"])
+    await select(page.mouse, 180, 120)
+    
+    await page.evaluate(() => ds.setSettings({ immediateDrag: true }))
+    await moveItem(page.mouse, 140, 85)
+    await select(page.mouse, 180, 85)
+    cb = await selectItems(page.mouse, 140, 85)
+    expect(cb).toMatchObject(["one"])
+  })
+
+  it('scroll swapping should work', async () => {
+    await page.goto(`${baseUrl}/settings.html`)
+    await page.evaluate(() =>
+      ds.setSettings({
+        draggability: true,
+        immediateDrag: true,
+        autoScrollSpeed: 1000,
+        overflowTolerance: { x: 200, y: 200 }
+      }))
+    await moveItem(page.mouse, 140, 85)
+    expect(await page.evaluate(() =>
+      ds.Area.HTMLNode.scrollTop)).not.toBe(0)
+  })
+
+  it('keyboard swapping should work', async () => {
+    await page.goto(`${baseUrl}/settings.html`)
+    await page.evaluate(() =>
+      ds.setSettings({
+        draggability: true,
+        keyboardDrag: true,
+        dragKeys: {
+            down: ['s'],
+        },
+        keyboardDragSpeed: 100,
+      }))
+    
+    let cb = []
+    cb = await selectItems(page.mouse, 140, 85)
+    expect(cb?.sort()).toMatchObject(["one", "two"])
+    await select(page.mouse, 180, 120)
+    await moveItemKey(page.mouse, page.keyboard, 140, 85, 's')
+    expect(await page.evaluate(() =>
+      ds.Area.HTMLNode.scrollTop)).not.toBe(0)
+    await page.evaluate(() =>
+      ds.Area.HTMLNode.scrollTop = 0)
+    await select(page.mouse, 180, 120)
+    cb = await selectItems(page.mouse, 140, 85)
+    expect(cb).toMatchObject(["one"])
+  })
+
+  it('useTransform swapping should work', async () => {
+    await page.goto(`${baseUrl}/settings.html`)
+    await page.evaluate(() =>
+      ds.setSettings({
+        draggability: true,
+        immediateDrag: true,
+        useTransform: false,
+      }))
+    await moveItem(page.mouse, 140, 85)
+    expect(await page.evaluate(() =>
+      document.querySelector("#two").style.top)).not.toBe(0)
+    expect(await page.evaluate(() =>
+      document.querySelector("#two").style.transform)).toBe('')
+  })
+
+  it('multiSelectKeys swapping should work', async () => {
+    await page.goto(`${baseUrl}/settings.html`)
+    await page.evaluate(() =>
+      ds.setSettings({
+        multiSelectKeys: ['q'],
+      }))
+    await select(page.mouse, 140, 85)
+    await page.keyboard.down('Shift')
+    await select(page.mouse, 85, 85)
+    await page.keyboard.up('Shift')
+    expect(await page.evaluate(() =>
+      document.querySelectorAll(".ds-selected").length)).toBe(1)
+    await page.keyboard.down('q')
+    await select(page.mouse, 140, 85)
+    expect(await page.evaluate(() =>
+      document.querySelectorAll(".ds-selected").length)).toBe(2)
+    await page.keyboard.up('q')
+  })
+
+  it('multiSelectMode swapping should work', async () => {
+    await page.goto(`${baseUrl}/settings.html`)
+
+    await select(page.mouse, 140, 85)
+    await select(page.mouse, 85, 85)
+    expect(await page.evaluate(() =>
+      document.querySelectorAll(".ds-selected").length)).toBe(1)
+
+    await page.evaluate(() =>
+      ds.setSettings({
+        multiSelectMode: true
+      }))
+    await select(page.mouse, 140, 85)
+    expect(await page.evaluate(() =>
+      document.querySelectorAll(".ds-selected").length)).toBe(2)
+  })
+
+  it('multiSelectToggling swapping should work', async () => {
+    await page.goto(`${baseUrl}/settings.html`)
+    let cb = []
+    cb = await selectItems(page.mouse, 180, 120)
+    expect(cb?.sort()).toMatchObject(["one", "two"])
+    await page.keyboard.down("Shift")
+    cb = await selectItems(page.mouse, 180, 120)
+    expect(cb?.sort()).toMatchObject([])
+
+    await page.evaluate(() =>
+      ds.setSettings({
+        multiSelectToggling: false
+      }))
+    
+    cb = await selectItems(page.mouse, 180, 120)
+    expect(cb?.sort()).toMatchObject(["one", "two"])
+    await page.keyboard.down("Shift")
+    cb = await selectItems(page.mouse, 180, 120)
+    expect(cb?.sort()).toMatchObject(["one", "two"])
+  })
+})

--- a/deploying.md
+++ b/deploying.md
@@ -11,21 +11,24 @@ if you are a regular contributor, see [contibuting](CONTRIBUTING.md) and make a 
 
 ## Deploying
 
-Tipically you don’t have to do this, since you most likely are not the project owner.  
+Typically you don’t have to do this, since you most likely are not the project owner.  
 But if you are the project owner:
 
-- Travis will take care of deployment to gh-pages when you push/merge to github (gh-pages will be build by travis)
+- Travis will take care of deployment to gh-pages when you push/merge to github (gh-pages will be build by Travis)
 
 If this was successful, the next step is to publish the new version on `npm`:
 
 ```
 npm version patch
 npm run rollup
-npm publish
 ```
 Rollup is necessary for npm packages (since `dist` will be deployed to npm but is ignored in repo)
 
 versions are either `patch` wich changes 0.0.x, `minor` wich changes 0.x.0 or `major` for x.0.0.  
 See [npm docs](https://docs.npmjs.com/getting-started/publishing-npm-packages)  
 
-After that push again, just to make sure
+After that push again, just to make sure and then publish
+
+```
+npm publish
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2765,13 +2765,13 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.16.tgz",
+      "integrity": "sha512-LCQ+NeThyJ4k1W2d+vIKdxuSt9R3pQSZ4P92m7EakaYuXcVWbHuT5bjNcqLd4Rdgi6xYWYDvBJZJLZSLanjDcA==",
       "dev": true,
       "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "@nicolo-ribaudo/chokidar-2": {
@@ -3013,6 +3013,28 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "dev": true
+    },
+    "@types/markdown-it": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "dev": true,
+      "requires": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
       "dev": true
     },
     "@types/node": {
@@ -4145,12 +4167,12 @@
       "dev": true
     },
     "catharsis": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
-      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.15"
       }
     },
     "center-align": {
@@ -4245,9 +4267,9 @@
           }
         },
         "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4999,9 +5021,9 @@
       }
     },
     "entities": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
       "dev": true
     },
     "error-ex": {
@@ -5155,9 +5177,9 @@
           }
         },
         "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -6059,9 +6081,9 @@
           }
         },
         "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -8954,12 +8976,12 @@
       }
     },
     "js2xmlparser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.1.tgz",
-      "integrity": "sha512-KrPTolcw6RocpYjdC7pL7v62e55q7qOMHvLX1UCLc5AAS8qeJ6nukarEJAF2KL2PZxlbGueEbINqZR2bDe/gUw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
       "dev": true,
       "requires": {
-        "xmlcreate": "^2.0.3"
+        "xmlcreate": "^2.0.4"
       }
     },
     "jsbn": {
@@ -8969,25 +8991,26 @@
       "dev": true
     },
     "jsdoc": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.6.tgz",
-      "integrity": "sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==",
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
+      "integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.9.4",
+        "@types/markdown-it": "^12.2.3",
         "bluebird": "^3.7.2",
-        "catharsis": "^0.8.11",
+        "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
-        "js2xmlparser": "^4.0.1",
+        "js2xmlparser": "^4.0.2",
         "klaw": "^3.0.0",
-        "markdown-it": "^10.0.0",
-        "markdown-it-anchor": "^5.2.7",
-        "marked": "^0.8.2",
+        "markdown-it": "^12.3.2",
+        "markdown-it-anchor": "^8.4.1",
+        "marked": "^4.0.10",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
         "strip-json-comments": "^3.1.0",
         "taffydb": "2.6.2",
-        "underscore": "~1.10.2"
+        "underscore": "~1.13.2"
       },
       "dependencies": {
         "escape-string-regexp": {
@@ -9034,9 +9057,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.7.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-          "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
           "dev": true
         },
         "agent-base": {
@@ -9123,14 +9146,15 @@
           "optional": true
         },
         "tough-cookie": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-          "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
+          "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
           "dev": true,
           "requires": {
             "psl": "^1.1.33",
             "punycode": "^2.1.1",
-            "universalify": "^0.1.2"
+            "universalify": "^0.2.0",
+            "url-parse": "^1.5.3"
           }
         },
         "tr46": {
@@ -9152,12 +9176,6 @@
             "tr46": "^2.1.0",
             "webidl-conversions": "^6.1.0"
           }
-        },
-        "ws": {
-          "version": "7.5.8",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
-          "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
-          "dev": true
         }
       }
     },
@@ -9177,12 +9195,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
@@ -9213,15 +9225,23 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
+      },
+      "dependencies": {
+        "json-schema": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+          "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+          "dev": true
+        }
       }
     },
     "jstransformer": {
@@ -9309,9 +9329,9 @@
       "dev": true
     },
     "linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
       "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
@@ -9467,40 +9487,48 @@
       }
     },
     "markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        }
       }
     },
     "markdown-it-anchor": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
-      "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
+      "integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ==",
       "dev": true
     },
     "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
+      "integrity": "sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw==",
       "dev": true
     },
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "dev": true
     },
     "merge-deep": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
-      "integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
+      "integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
@@ -9511,7 +9539,7 @@
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -10117,9 +10145,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {
@@ -10537,6 +10565,12 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -10848,6 +10882,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
     "requizzle": {
@@ -11745,7 +11785,7 @@
     "taffydb": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA==",
       "dev": true
     },
     "tar-fs": {
@@ -11797,9 +11837,9 @@
       }
     },
     "terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
@@ -11809,9 +11849,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.7.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-          "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
           "dev": true
         },
         "commander": {
@@ -11868,9 +11908,9 @@
       "dev": true
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {
@@ -12046,9 +12086,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "uc.micro": {
@@ -12075,9 +12115,9 @@
       }
     },
     "underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -12121,9 +12161,9 @@
       }
     },
     "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "dev": true
     },
     "unset-value": {
@@ -12187,6 +12227,16 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
     },
     "use": {
       "version": "3.1.1",
@@ -12539,9 +12589,9 @@
       }
     },
     "ws": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
       "dev": true
     },
     "xml-name-validator": {
@@ -12557,9 +12607,9 @@
       "dev": true
     },
     "xmlcreate": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
-      "integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -61,13 +61,13 @@
     "glob": "^7.1.7",
     "jest": "^26.6.3",
     "jest-puppeteer": "^4.4.0",
-    "jsdoc": "^3.6.6",
+    "jsdoc": "^3.6.11",
     "minami": "^1.2.3",
     "prettier": "^2.2.1",
     "puppeteer": "^5.5.0",
     "rollup": "^2.36.1",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "^4.1.3"
+    "typescript": "^4.8.0"
   },
   "repository": {
     "type": "git",

--- a/src/methods/createSelectorAreaElement.js
+++ b/src/methods/createSelectorAreaElement.js
@@ -3,15 +3,13 @@ import '../types'
 
 /**
  * Creates the SelectorArea
- * @param {string} selectorAreaClass
  * @return {HTMLDivElement}
  */
-export default (selectorAreaClass) => {
+export default () => {
   const node = document.createElement('div')
   node.style.position = 'fixed'
   node.style.overflow = 'hidden'
   node.style.pointerEvents = 'none'
   node.style.zIndex = '999999999999999999'
-  node.classList.add(selectorAreaClass)
   return node
 }

--- a/src/methods/hydrateSettings.js
+++ b/src/methods/hydrateSettings.js
@@ -1,0 +1,103 @@
+/**
+ * @param {string} key 
+ * @param {string} type 
+ * @param {*} fallback
+ * @returns {void}
+ */
+const wrongTypeWarn = (key, type, fallback) => 
+  console.warn(`[DragSelect] TypeIssue: setting "${key}" is not of type "${type}".`)
+
+/**
+ * @param {string} key 
+ * @param {*} value
+ * @param {boolean} withFallback 
+ * @param {*} fallback 
+ * @returns {object}
+ */
+const hydrateHelper = (key, value, withFallback, fallback) => {
+  // no value available
+  if (value === undefined)
+    return withFallback ? { [key]: fallback } : {}
+  // force unsetting of a value
+  if (value === null) return { [key]: null }
+
+  // TypeCheck [GENERIC]
+  let isAvailable = true // if it’s not undefined, it was set voluntarily
+  let forceFallback = false
+
+  // TypeCheck [String]
+  const expectedString = typeof fallback === 'string'
+  if (expectedString) isAvailable = typeof value === 'string' || value instanceof String
+  if (expectedString && !isAvailable) {
+    forceFallback = true
+    wrongTypeWarn(key, 'string', fallback)
+  }
+
+  // TypeCheck [Number]
+  const expectedNumber = !isNaN(fallback) && typeof fallback === 'number'
+  if (expectedNumber) isAvailable = !isNaN(value) && typeof value === 'number'
+  if (expectedNumber && !isAvailable) {
+    forceFallback = true
+    wrongTypeWarn(key, 'number', fallback)
+  }
+
+  // TypeCheck [Object]
+  const expectedObject = Object.prototype.toString.call(fallback) === "[object Object]"
+  if (expectedObject) isAvailable = Object.prototype.toString.call(value) === "[object Object]"
+  if (expectedObject && !isAvailable) {
+    forceFallback = true
+    wrongTypeWarn(key, 'object', fallback)
+  }
+
+  // TypeCheck [Boolean]
+  const expectedBoolean = typeof fallback === "boolean"
+  if (expectedBoolean) isAvailable = typeof value === "boolean"
+  if (expectedBoolean && !isAvailable) {
+    forceFallback = true
+    wrongTypeWarn(key, 'boolean', fallback)
+  }
+
+  // TypeCheck [Array]
+  const expectedArray = Array.isArray(fallback)
+  if (expectedArray) isAvailable = Array.isArray(value)
+  if (expectedArray && !isAvailable) {
+    forceFallback = true
+    wrongTypeWarn(key, 'array', fallback)
+  }
+
+  const isFallback = forceFallback || withFallback
+
+  // Special rule for [dragKeys]
+  if (key === 'dragKeys' && isAvailable) return { [key]: Object.assign(fallback, value) }
+  else if(key === 'dragKeys' && !isAvailable) return isFallback ? { [key]: fallback } : {}
+
+  return isAvailable ? { [key]: value } : isFallback ? { [key]: fallback } : {}
+}
+
+/**
+ * @param {Settings} settings 
+ * @param {boolean} withFallback 
+ */
+export default (settings, withFallback) => ({
+  ...hydrateHelper('area', settings.area, withFallback, document),
+  ...hydrateHelper('selectables', settings.selectables, withFallback, null),
+  ...hydrateHelper('autoScrollSpeed', settings.autoScrollSpeed, withFallback, 5),
+  ...hydrateHelper('overflowTolerance', settings.overflowTolerance, withFallback, { x: 25, y: 25 }),
+  ...hydrateHelper('zoom', settings.zoom, withFallback, 1),
+  ...hydrateHelper('customStyles', settings.customStyles, withFallback, false),
+  ...hydrateHelper('multiSelectMode', settings.multiSelectMode, withFallback, false),
+  ...hydrateHelper('multiSelectToggling', settings.multiSelectToggling, withFallback, true),
+  ...hydrateHelper('multiSelectKeys', settings.multiSelectKeys, withFallback, ['Control', 'Shift', 'Meta']),
+  ...hydrateHelper('selector', settings.selector, withFallback, null),
+  ...hydrateHelper('draggability', settings.draggability, withFallback, true),
+  ...hydrateHelper('immediateDrag', settings.immediateDrag, withFallback, true),
+  ...hydrateHelper('keyboardDrag', settings.keyboardDrag, withFallback, true),
+  ...hydrateHelper('dragKeys', settings.dragKeys, withFallback, { up: ['ArrowUp'], down: ['ArrowDown'], left: ['ArrowLeft'], right: ['ArrowRight'] }),
+  ...hydrateHelper('keyboardDragSpeed', settings.keyboardDragSpeed, withFallback, 10),
+  ...hydrateHelper('useTransform', settings.useTransform, withFallback, true),
+  ...hydrateHelper('hoverClass', settings.hoverClass, withFallback, 'ds-hover'),
+  ...hydrateHelper('selectableClass', settings.selectableClass, withFallback, 'ds-selectable'),
+  ...hydrateHelper('selectedClass', settings.selectedClass, withFallback, 'ds-selected'),
+  ...hydrateHelper('selectorClass', settings.selectorClass, withFallback, 'ds-selector'),
+  ...hydrateHelper('selectorAreaClass', settings.selectorAreaClass, withFallback, 'ds-selector-area'),
+})

--- a/src/methods/hydrateSettings.js
+++ b/src/methods/hydrateSettings.js
@@ -75,6 +75,12 @@ const hydrateHelper = (key, value, withFallback, fallback) => {
 }
 
 /**
+ * This helper method creates the setting object,
+ * - if the settings provided are of wrong type, the fallback value will be used
+ * - - except for if settings are undefined or explicitly marked as "null"
+ * - if "withfallback" is true, it will return the object with all settings: 
+ * - - if not provided from the settings object (or wrong type), the fallback will be used
+ * (the fallback value for each setting is the last prop of the hydrateHelper)
  * @param {Settings} settings 
  * @param {boolean} withFallback 
  */

--- a/src/methods/index.js
+++ b/src/methods/index.js
@@ -16,6 +16,7 @@ export { default as handleElementPositionAttribute } from './handleElementPositi
 export { default as handleKeyboardDragPosDifference } from './handleKeyboardDragPosDifference'
 export { default as handleSelection } from './handleSelection'
 export { default as handleUnSelection } from './handleUnSelection'
+export { default as hydrateSettings } from './hydrateSettings'
 export { default as isCollision } from './isCollision'
 export { default as moveElement } from './moveElement'
 export { default as removeModificationObservers } from './removeModificationObservers'

--- a/src/modules/Drag.js
+++ b/src/modules/Drag.js
@@ -6,11 +6,6 @@ import { vect2, moveElement, handleKeyboardDragPosDifference } from '../methods'
 
 export default class Drag {
   /**
-   * @type {boolean}
-   * @private
-   */
-  _useTransform
-  /**
    * @type {Vect2}
    * @private
    */
@@ -26,11 +21,6 @@ export default class Drag {
    */
   _elements = []
   /**
-   * @type {boolean}
-   * @private
-   */
-  _draggability
-  /**
    * @type {DSDragKeys}
    * @private
    */
@@ -39,63 +29,19 @@ export default class Drag {
    * @type {string[]}
    * @private
    */
-  _dragKeysFlat
-  /**
-   * @type {boolean}
-   * @private
-   */
-  _keyboardDrag
-  /**
-   * @type {number}
-   * @private
-   */
-  _keyboardDragSpeed
-  /**
-   * @type {number}
-   * @private
-   */
-  _zoom
+  _dragKeysFlat = []
 
   /**
    * @param {Object} p
    * @param {DragSelect} p.DS
-   * @param {boolean} p.draggability
-   * @param {boolean} p.useTransform
-   * @param {DSDragKeys} p.dragKeys
-   * @param {boolean} p.keyboardDrag
-   * @param {number} p.keyboardDragSpeed
-   * @param {number} p.zoom
    * @ignore
    */
-  constructor({
-    DS,
-    dragKeys,
-    draggability,
-    keyboardDrag,
-    keyboardDragSpeed,
-    useTransform,
-    zoom,
-  }) {
+  constructor({ DS }) {
     this.DS = DS
-    this._useTransform = useTransform
-    this._keyboardDragSpeed = keyboardDragSpeed
-    this._keyboardDrag = keyboardDrag
-    this._zoom = zoom
-    this._draggability = draggability
 
-    this._dragKeys = {
-      up: dragKeys.up.map((k) => k.toLowerCase()),
-      down: dragKeys.down.map((k) => k.toLowerCase()),
-      left: dragKeys.left.map((k) => k.toLowerCase()),
-      right: dragKeys.right.map((k) => k.toLowerCase()),
-    }
-    this._dragKeysFlat = [
-      ...this._dragKeys.up,
-      ...this._dragKeys.down,
-      ...this._dragKeys.left,
-      ...this._dragKeys.right,
-    ]
-
+    // @ts-ignore: @todo: update to typescript
+    this.DS.subscribe('Settings:updated:dragKeys', this.assignDragkeys)
+    this.assignDragkeys()
     this.DS.subscribe('Interaction:start', this.start)
     this.DS.subscribe('Interaction:end', this.stop)
     this.DS.subscribe('Interaction:update', this.update)
@@ -103,12 +49,28 @@ export default class Drag {
     this.DS.subscribe('KeyStore:up', this.keyboardEnd)
   }
 
+  assignDragkeys = () => {
+    this._dragKeys = {
+      up: this.DS.stores.SettingsStore.s.dragKeys.up.map((k) => k.toLowerCase()),
+      down: this.DS.stores.SettingsStore.s.dragKeys.down.map((k) => k.toLowerCase()),
+      left: this.DS.stores.SettingsStore.s.dragKeys.left.map((k) => k.toLowerCase()),
+      right: this.DS.stores.SettingsStore.s.dragKeys.right.map((k) => k.toLowerCase()),
+    }
+    this._dragKeysFlat = [
+      ...this._dragKeys.up,
+      ...this._dragKeys.down,
+      ...this._dragKeys.left,
+      ...this._dragKeys.right,
+    ]
+  }
+
   keyboardDrag = ({ event, key }) => {
+    const _key = key.toLowerCase()
     if (
-      !this._keyboardDrag ||
-      !this._dragKeysFlat.includes(key) ||
+      !this.DS.stores.SettingsStore.s.keyboardDrag ||
+      !this._dragKeysFlat.includes(_key) ||
       !this.DS.SelectedSet.size ||
-      !this._draggability ||
+      !this.DS.stores.SettingsStore.s.draggability ||
       this.DS.continue
     )
       return
@@ -125,9 +87,9 @@ export default class Drag {
 
     const posDirection = handleKeyboardDragPosDifference({
       shiftKey: this.DS.stores.KeyStore.currentValues.includes('shift'),
-      keyboardDragSpeed: this._keyboardDragSpeed,
-      zoom: this._zoom,
-      key,
+      keyboardDragSpeed: this.DS.stores.SettingsStore.s.keyboardDragSpeed,
+      zoom: this.DS.stores.SettingsStore.s.zoom,
+      key: _key,
       scrollCallback: this.DS.Area.scroll,
       scrollDiff: this._scrollDiff,
       canScroll: this.DS.stores.ScrollStore.canScroll,
@@ -139,24 +101,28 @@ export default class Drag {
         element,
         posDirection,
         containerRect: this.DS.SelectorArea.rect,
-        useTransform: this._useTransform,
+        useTransform: this.DS.stores.SettingsStore.s.useTransform,
       })
     )
 
-    this.DS.publish(['Interaction:update:pre', 'Interaction:update'], publishData)
+    this.DS.publish(
+      ['Interaction:update:pre', 'Interaction:update'],
+      publishData
+    )
   }
 
   keyboardEnd = ({ event, key }) => {
+    const _key = key.toLowerCase()
     if (
-      !this._keyboardDrag ||
-      !this._dragKeysFlat.includes(key) ||
+      !this.DS.stores.SettingsStore.s.keyboardDrag ||
+      !this._dragKeysFlat.includes(_key) ||
       !this.DS.SelectedSet.size ||
-      !this._draggability
+      !this.DS.stores.SettingsStore.s.draggability
     )
       return
     const publishData = {
       event,
-      isDragging: this._draggability,
+      isDragging: this.DS.stores.SettingsStore.s.draggability,
       isDraggingKeyboard: true,
     }
     this.DS.publish(['Interaction:end:pre', 'Interaction:end'], publishData)
@@ -194,7 +160,7 @@ export default class Drag {
         element,
         posDirection,
         containerRect: this.DS.SelectorArea.rect,
-        useTransform: this._useTransform,
+        useTransform: this.DS.stores.SettingsStore.s.useTransform,
       })
     )
   }

--- a/src/modules/Drag.js
+++ b/src/modules/Drag.js
@@ -32,8 +32,8 @@ export default class Drag {
   _dragKeysFlat = []
 
   /**
-   * @param {Object} p
-   * @param {DragSelect} p.DS
+   * @constructor Drag
+   * @param {{DS:DragSelect}} obj
    * @ignore
    */
   constructor({ DS }) {

--- a/src/modules/Interaction.js
+++ b/src/modules/Interaction.js
@@ -10,8 +10,7 @@ export default class Interaction {
 
   /**
    * @constructor Interaction
-   * @param {Object} obj
-   * @param {DragSelect} obj.DS
+   * @param {{DS:DragSelect}} obj
    * @ignore
    */
   constructor({ DS }) {

--- a/src/modules/SelectableSet.js
+++ b/src/modules/SelectableSet.js
@@ -7,8 +7,7 @@ import { toArray, handleElementPositionAttribute } from '../methods'
 export default class SelectableSet extends Set {
   /**
    * @constructor SelectableSet
-   * @param {Object} p
-   * @param {DragSelect} p.DS
+   * @param {{DS:DragSelect}} obj
    * @ignore
    */
   constructor({ DS }) {

--- a/src/modules/SelectableSet.js
+++ b/src/modules/SelectableSet.js
@@ -6,66 +6,37 @@ import { toArray, handleElementPositionAttribute } from '../methods'
 
 export default class SelectableSet extends Set {
   /**
-   * @type {DSElements}
-   * @private
-   * */
-  _initElements
-  /**
-   * @type {string}
-   * @private
-   * */
-  _className
-  /**
-   * @type {string}
-   * @private
-   * */
-  _hoverClassName
-  /**
-   * @type {boolean}
-   * @private
-   * */
-  _useTransform
-  /**
-   * @type {boolean}
-   * @private
-   * */
-  _draggability
-
-  /**
    * @constructor SelectableSet
    * @param {Object} p
-   * @param {DSInputElements} p.elements
    * @param {DragSelect} p.DS
-   * @param {string} p.className
-   * @param {string} p.hoverClassName
-   * @param {boolean} p.useTransform
-   * @param {boolean} p.draggability
    * @ignore
    */
-  constructor({
-    elements,
-    className,
-    hoverClassName,
-    draggability,
-    useTransform,
-    DS,
-  }) {
+  constructor({ DS }) {
     super()
     this.DS = DS
-    this._initElements = toArray(elements)
-    this._className = className
-    this._hoverClassName = hoverClassName
-    this._useTransform = useTransform
-    this._draggability = draggability
-
     this.DS.subscribe('Interaction:init', this.init)
+    // @ts-ignore: @todo: update to typescript
+    this.DS.PubSub.subscribe('Settings:updated:selectables', () => {
+      this.clear()
+      this.init()
+    })
+    // @ts-ignore: @todo: update to typescript
+    this.DS.subscribe('Settings:updated:selectableClass', ({ settings }) => {
+      this.forEach((el) => {
+        el.classList.remove(settings['selectableClass:pre'])
+        el.classList.add(settings['selectableClass'])
+      })
+    })
   }
 
-  init = () => this._initElements.forEach((el) => this.add(el))
+  init = () =>
+    toArray(this.DS.stores.SettingsStore.s.selectables).forEach((el) =>
+      this.add(el)
+    )
 
   /** @param {DSElement} element */
   add(element) {
-    element.classList.add(this._className)
+    element.classList.add(this.DS.stores.SettingsStore.s.selectableClass)
     element.addEventListener('click', this._onClick)
     element.addEventListener('mousedown', this._onPointer)
     element.addEventListener('touchstart', this._onPointer, {
@@ -73,7 +44,10 @@ export default class SelectableSet extends Set {
       passive: false,
     })
 
-    if (this._draggability && !this._useTransform)
+    if (
+      this.DS.stores.SettingsStore.s.draggability &&
+      !this.DS.stores.SettingsStore.s.useTransform
+    )
       handleElementPositionAttribute({
         computedStyle: window.getComputedStyle(element),
         node: element,
@@ -84,8 +58,8 @@ export default class SelectableSet extends Set {
 
   /** @param {DSElement} element */
   delete(element) {
-    element.classList.remove(this._className)
-    element.classList.remove(this._hoverClassName)
+    element.classList.remove(this.DS.stores.SettingsStore.s.selectableClass)
+    element.classList.remove(this.DS.stores.SettingsStore.s.hoverClass)
     element.removeEventListener('click', this._onClick)
     element.removeEventListener('mousedown', this._onPointer)
     element.removeEventListener('touchstart', this._onPointer, {
@@ -97,8 +71,10 @@ export default class SelectableSet extends Set {
 
   clear = () => this.forEach((el) => this.delete(el))
 
-  _onClick = (event) => this.DS.publish(['Selectable:click:pre', 'Selectable:click'], { event })
-  _onPointer = (event) => this.DS.publish(['Selectable:pointer:pre', 'Selectable:pointer'], { event })
+  _onClick = (event) =>
+    this.DS.publish(['Selectable:click:pre', 'Selectable:click'], { event })
+  _onPointer = (event) =>
+    this.DS.publish(['Selectable:pointer:pre', 'Selectable:pointer'], { event })
 
   /** @param {DSElements} elements */
   addAll = (elements) => elements.forEach((el) => this.add(el))

--- a/src/modules/SelectedSet.js
+++ b/src/modules/SelectedSet.js
@@ -5,8 +5,7 @@ import DragSelect from '../DragSelect'
 export default class SelectedSet extends Set {
   /**
    * @constructor SelectableSet
-   * @param {Object} p
-   * @param {DragSelect} p.DS
+   * @param {{DS:DragSelect}} obj
    * @ignore
    */
   constructor({ DS }) {

--- a/src/modules/SelectedSet.js
+++ b/src/modules/SelectedSet.js
@@ -4,22 +4,14 @@ import DragSelect from '../DragSelect'
 
 export default class SelectedSet extends Set {
   /**
-   * @type {string}
-   * @private
-   * */
-  _className
-
-  /**
    * @constructor SelectableSet
    * @param {Object} p
    * @param {DragSelect} p.DS
-   * @param {string} p.className
    * @ignore
    */
-  constructor({ className, DS }) {
+  constructor({ DS }) {
     super()
     this.DS = DS
-    this._className = className
   }
 
   /** @param {DSElement} element */
@@ -31,7 +23,7 @@ export default class SelectedSet extends Set {
     }
     this.DS.publish('Selected:added:pre', publishData)
     super.add(element)
-    element.classList.add(this._className)
+    element.classList.add(this.DS.stores.SettingsStore.s.selectedClass)
     element.style.zIndex = `${(parseInt(element.style.zIndex) || 0) + 1}`
     this.DS.publish('Selected:added', publishData)
     return this
@@ -46,7 +38,7 @@ export default class SelectedSet extends Set {
     }
     this.DS.publish('Selected:removed:pre', publishData)
     const deleted = super.delete(element)
-    element.classList.remove(this._className)
+    element.classList.remove(this.DS.stores.SettingsStore.s.selectedClass)
     element.style.zIndex = `${(parseInt(element.style.zIndex) || 0) - 1}`
     this.DS.publish('Selected:removed', publishData)
     return deleted

--- a/src/modules/Selection.js
+++ b/src/modules/Selection.js
@@ -10,26 +10,13 @@ export default class Selection {
    * @private
    * */
   _prevSelectedSet
-  /**
-   * @type {string}
-   * @private
-   * */
-  _hoverClassName
-  /**
-   * @type {boolean}
-   * @private
-   * */
-  _multiSelectToggling
 
   /**
    * @constructor Selection
-   * @param {{ DS:DragSelect, hoverClassName:string, multiSelectToggling:boolean }} p
+   * @param {{ DS:DragSelect }} p
    * @ignore
    */
-  constructor({ DS, hoverClassName, multiSelectToggling }) {
-    this._hoverClassName = hoverClassName
-    this._multiSelectToggling = multiSelectToggling
-
+  constructor({ DS }) {
     this.DS = DS
     this.DS.subscribe('Interaction:start', this.start)
     this.DS.subscribe('Interaction:update', this.update)
@@ -88,8 +75,8 @@ export default class Selection {
     }
 
     const multiSelectionToggle =
-      this.DS.stores.KeyStore.isMultiSelectKeyPressed(event) &&
-      this._multiSelectToggling
+      (this.DS.stores.KeyStore.isMultiSelectKeyPressed(event)) &&
+      this.DS.stores.SettingsStore.s.multiSelectToggling
 
     if (this.DS.continue) return
     select.forEach((element) =>
@@ -98,7 +85,7 @@ export default class Selection {
         force,
         multiSelectionToggle,
         SelectedSet: this.DS.SelectedSet,
-        hoverClassName: this._hoverClassName,
+        hoverClassName: this.DS.stores.SettingsStore.s.hoverClass,
       })
     )
     unselect.forEach((element) =>
@@ -106,7 +93,7 @@ export default class Selection {
         element,
         force,
         SelectedSet: this.DS.SelectedSet,
-        hoverClassName: this._hoverClassName,
+        hoverClassName: this.DS.stores.SettingsStore.s.hoverClass,
         PrevSelectedSet: this._prevSelectedSet,
       })
     )

--- a/src/modules/Selector.js
+++ b/src/modules/Selector.js
@@ -18,22 +18,35 @@ export default class Selector {
 
   /**
    * @constructor Selector
-   * @param {Object} p
-   * @param {DragSelect} p.DS
-   * @param {HTMLElement} p.selector
-   * @param {string} p.selectorClass
-   * @param {boolean} p.customStyles
+   * @param {{ DS:DragSelect }} p
    * @ignore
    */
-  constructor({ DS, selector, selectorClass, customStyles }) {
+  constructor({ DS }) {
     this.DS = DS
 
-    this.HTMLNode = selector || createSelectorElement(customStyles)
-    this.HTMLNode.classList.add(selectorClass)
+    // @ts-ignore: @todo: update to typescript
+    this.DS.subscribe('Settings:updated:selectorClass', ({ settings }) => {
+      this.HTMLNode.classList.remove(settings['selectorClass:pre'])
+      this.HTMLNode.classList.add(settings['selectorClass'])
+    })
+    // @ts-ignore: @todo: update to typescript
+    this.DS.subscribe('Settings:updated:selector', this.attachSelector)
+    this.attachSelector()
 
     this.DS.subscribe('Interaction:start', this.start)
     this.DS.subscribe('Interaction:update', this.update)
     this.DS.subscribe('Interaction:end', this.stop)
+  }
+  
+  attachSelector = () => {
+    if (this.HTMLNode && this.DS.SelectorArea?.HTMLNode)
+      this.DS.SelectorArea.HTMLNode.removeChild(this.HTMLNode)
+    this.HTMLNode =
+      this.DS.stores.SettingsStore.s.selector ||
+      createSelectorElement(this.DS.stores.SettingsStore.s.customStyles)
+    this.HTMLNode.classList.add(this.DS.stores.SettingsStore.s.selectorClass)
+    if (this.HTMLNode && this.DS.SelectorArea?.HTMLNode)
+      this.DS.SelectorArea.HTMLNode.appendChild(this.HTMLNode)
   }
 
   start = ({ isDragging }) => {

--- a/src/modules/SelectorArea.js
+++ b/src/modules/SelectorArea.js
@@ -10,11 +10,6 @@ import {
 
 export default class SelectorArea {
   /**
-   * @type {number}
-   * @private
-   * */
-  _autoScrollSpeed
-  /**
    * @type {*}
    * @private
    * */
@@ -29,25 +24,25 @@ export default class SelectorArea {
    * @private
    */
   currentEdges = []
-  /**
-   * @type {Vect2}
-   * @private
-   */
-  _overflowTolerance
 
   /**
    * @class SelectorArea
    * @constructor SelectorArea
-   * @param {{ DS:DragSelect, selectorAreaClass:string, autoScrollSpeed:number, overflowTolerance:Vect2}} obj
+   * @param {{ DS:DragSelect }} obj
    * @ignore
    */
-  constructor({ DS, selectorAreaClass, autoScrollSpeed, overflowTolerance }) {
-    this._autoScrollSpeed = autoScrollSpeed
-    this._overflowTolerance = overflowTolerance
+  constructor({ DS }) {
     this.DS = DS
 
-    this.HTMLNode = createSelectorAreaElement(selectorAreaClass)
+    this.HTMLNode = createSelectorAreaElement()
+    // @ts-ignore: @todo: update to typescript
+    this.DS.subscribe('Settings:updated:selectorAreaClass', ({ settings }) => {
+      this.HTMLNode.classList.remove(settings['selectorAreaClass:pre'])
+      this.HTMLNode.classList.add(settings['selectorAreaClass'])
+    })
+    this.HTMLNode.classList.add(this.DS.stores.SettingsStore.s.selectorAreaClass)
 
+    this.DS.subscribe('Area:modified', this.updatePos)
     this.DS.subscribe('Area:modified', this.updatePos)
     this.DS.subscribe('Interaction:init', this.start)
     this.DS.subscribe('Interaction:start', this.startAutoScroll)
@@ -110,11 +105,11 @@ export default class SelectorArea {
     this.currentEdges = getOverflowEdges({
       elementRect: vect2.vect2rect(PointerStore.currentVal),
       containerRect: this.rect,
-      tolerance: this._overflowTolerance,
+      tolerance: this.DS.stores.SettingsStore.s.overflowTolerance,
     })
 
     if (this.currentEdges.length)
-      Area.scroll(this.currentEdges, this._autoScrollSpeed)
+      Area.scroll(this.currentEdges, this.DS.stores.SettingsStore.s.autoScrollSpeed)
   }
 
   stopAutoScroll = () => {

--- a/src/stores/KeyStore.js
+++ b/src/stores/KeyStore.js
@@ -4,16 +4,6 @@ import DragSelect from '../DragSelect'
 
 export default class KeyStore {
   /**
-   * @type {boolean}
-   * @private
-   * */
-  _multiSelectMode
-  /**
-   * @type {DSMultiSelectKeys}
-   * @private
-   * */
-  _multiSelectKeys
-  /**
    * @type {Set<string>}
    * @private
    * */
@@ -31,31 +21,11 @@ export default class KeyStore {
   /**
    * @class KeyStore
    * @constructor KeyStore
-   * @param {{DS:DragSelect,multiSelectKeys:DSMultiSelectKeys,multiSelectMode:boolean}} p
+   * @param {{DS:DragSelect}} p
    * @ignore
    */
-  constructor({ DS, multiSelectKeys, multiSelectMode }) {
+  constructor({ DS }) {
     this.DS = DS
-    this._multiSelectMode = multiSelectMode
-
-    // @TODO: remove after deprecation
-    this._multiSelectKeys = multiSelectKeys.map((key) => {
-      const deprecatedKeys = {
-        ctrlKey: 'Control',
-        shiftKey: 'Shift',
-        metaKey: 'Meta',
-      }
-      /** @type {string} */
-      const newName = deprecatedKeys[key]
-      if (newName) {
-        console.warn(
-          `[DragSelect] ${key} is deprecated. Use "${newName}" instead. Act Now!. See docs for more info`
-        )
-        return newName.toLowerCase()
-      }
-      return key.toLowerCase()
-    })
-
     this.DS.subscribe('Interaction:init', this.init)
   }
 
@@ -92,13 +62,17 @@ export default class KeyStore {
 
   /** @param {KeyboardEvent|MouseEvent|TouchEvent} [event] */
   isMultiSelectKeyPressed(event) {
-    if (this._multiSelectMode) return true
-    if (this.currentValues.some((key) => this._multiSelectKeys.includes(key)))
-      return true
-    if (
-      event &&
-      this._multiSelectKeys.some((key) => event[this._keyMapping[key]])
+    if(this.DS.stores.SettingsStore.s.multiSelectMode) return true
+    const multiSelectKeys = this.DS.stores.SettingsStore.s.multiSelectKeys.map(
+      (key) => key.toLocaleLowerCase()
     )
+    if (
+      this.currentValues.some((key) =>
+        multiSelectKeys.includes(key.toLocaleLowerCase())
+      )
+    )
+      return true
+    if (event && multiSelectKeys.some((key) => event[this._keyMapping[key]]))
       return true
     return false
   }

--- a/src/stores/ScrollStore.js
+++ b/src/stores/ScrollStore.js
@@ -13,10 +13,6 @@ export default class ScrollStore {
    * @private */
   _currentVal
   /**
-   * @type {DSArea}
-   * @private */
-  _areaElement
-  /**
    * @type {boolean}
    * @private */
   _canScroll
@@ -24,30 +20,34 @@ export default class ScrollStore {
   /**
    * @class ScrollStore
    * @constructor ScrollStore
-   * @param {{ DS:DragSelect, areaElement: DSArea, zoom:number }} p
+   * @param {{ DS:DragSelect }} p
    * @ignore
    */
-  constructor({ DS, areaElement, zoom }) {
-    this._areaElement = areaElement
+  constructor({ DS }) {
     this.DS = DS
-    this.zoom = zoom
-
     this.DS.subscribe('Interaction:init', this.init)
     this.DS.subscribe('Interaction:start', () => this.start())
     this.DS.subscribe('Interaction:end', () => this.reset())
   }
 
-  init = () => this._areaElement.addEventListener('scroll', this.update)
+  init = () =>
+    this.DS.stores.SettingsStore.s.area.addEventListener('scroll', this.update)
 
   start = () => {
-    this._currentVal = this._initialVal = getCurrentScroll(this._areaElement)
-    this._areaElement.addEventListener('scroll', this.update)
+    this._currentVal = this._initialVal = getCurrentScroll(
+      this.DS.stores.SettingsStore.s.area
+    )
+    this.DS.stores.SettingsStore.s.area.addEventListener('scroll', this.update)
   }
 
-  update = () => (this._currentVal = getCurrentScroll(this._areaElement))
+  update = () =>
+    (this._currentVal = getCurrentScroll(this.DS.stores.SettingsStore.s.area))
 
   stop = () => {
-    this._areaElement.removeEventListener('scroll', this.update)
+    this.DS.stores.SettingsStore.s.area.removeEventListener(
+      'scroll',
+      this.update
+    )
     this._initialVal = { x: 0, y: 0 }
     this._canScroll = null
   }
@@ -59,14 +59,14 @@ export default class ScrollStore {
 
   get canScroll() {
     if (typeof this._canScroll === 'boolean') return this._canScroll
-    return (this._canScroll = canScroll(this._areaElement))
+    return (this._canScroll = canScroll(this.DS.stores.SettingsStore.s.area))
   }
 
   get scrollAmount() {
     const scrollDiff = vect2.calc(this.currentVal, '-', this.initialVal)
 
     // if area is zoomed, the scroll values are skewed, we need to fix that manually :(
-    const zoom = vect2.num2vect(this.zoom)
+    const zoom = vect2.num2vect(this.DS.stores.SettingsStore.s.zoom)
     const zoomScroll = vect2.calc(
       vect2.calc(scrollDiff, '*', zoom),
       '-',
@@ -86,7 +86,7 @@ export default class ScrollStore {
 
   get currentVal() {
     if (!this._currentVal)
-      this._currentVal = getCurrentScroll(this._areaElement)
+      this._currentVal = getCurrentScroll(this.DS.stores.SettingsStore.s.area)
     return this._currentVal
   }
 }

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -4,9 +4,6 @@ import DragSelect from '../DragSelect'
 
 import { hydrateSettings } from '../methods'
 
-/**
- * @type {Settings}
- * */
 export default class SettingsStore {
   /**
    * @type {Settings}

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -1,0 +1,70 @@
+// @ts-check
+import '../types'
+import DragSelect from '../DragSelect'
+
+import { hydrateSettings } from '../methods'
+
+/**
+ * @type {Settings}
+ * */
+export default class SettingsStore {
+  /**
+   * @type {Settings}
+   * @private
+   * */
+  _settings = {}
+
+  /**
+   * Holds the settings and their previous value `:pre`
+   * @example {
+   *    autoScrollSpeed: 3,
+   *    'autoScrollSpeed:pre': 5
+   * }
+   * @type {Settings}
+   * */
+  s = {}
+
+  /**
+   * @class ScrollStore
+   * @constructor ScrollStore
+   * @param {{ DS:DragSelect, settings:Settings }} p
+   * @ignore
+   */
+  constructor({
+    DS,
+    settings
+  }) {
+    this.DS = DS
+    this.DS.subscribe('Settings:updated:pre', this._update)
+    this.update({ settings, init: true })
+  }
+
+  /** @param {{settings: Settings, init?: boolean}} props */
+  update = ({ settings, init }) =>
+    this.DS.publish('Settings:updated:pre', { settings, ...init ? { init } : {} })
+  /** @param {{settings: Settings, init: boolean}} props */
+  _update = ({ settings, init }) => {
+    const _settings = hydrateSettings(settings, init)
+    for (const [key, value] of Object.entries(_settings)) {
+      if (!(key in this._settings)) {
+        Object.defineProperty(this.s, key, {
+          get: () => this._settings[key],
+          set: (newValue) => this.update({ settings: { [key]: newValue } }),
+        })
+      }
+
+      this._settings[`${key}:pre`] = this._settings[key]
+      this._settings[key] = value
+
+      const update = {
+        settings: {
+          [key]: this._settings[key],
+          [`${key}:pre`]: this._settings[`${key}:pre`],
+        },
+      }
+      this.DS.publish('Settings:updated', update)
+      // @ts-ignore: @todo: update to typescript
+      this.DS.publish(`Settings:updated:${key}`, update)
+    }
+  }
+}

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,3 +1,4 @@
 export { default as KeyStore } from './KeyStore'
 export { default as PointerStore } from './PointerStore'
 export { default as ScrollStore } from './ScrollStore'
+export { default as SettingsStore } from './SettingsStore'

--- a/src/types.js
+++ b/src/types.js
@@ -22,12 +22,6 @@
  * @property {string} [selectedClass=ds-selected] the class assigned to the selected items
  * @property {string} [selectorClass=ds-selector] the class assigned to the square selector helper
  * @property {string} [selectorAreaClass=ds-selector-area] the class assigned to the square in which the selector resides. By default it's invisible
- * @property {DSCallback} [callback] Deprecated: please use DragSelect.subscribe('callback', callback) instead
- * @property {DSCallback} [onDragMove] Deprecated: please use DragSelect.subscribe('onDragMove', onDragMove) instead
- * @property {DSCallback} [onDragStartBegin] Deprecated: please use DragSelect.subscribe('onDragStartBegin', onDragStartBegin) instead
- * @property {DSCallback} [onDragStart] Deprecated: please use DragSelect.subscribe('onDragStart', onDragStart) instead
- * @property {DSCallback} [onElementSelect] Deprecated: please use DragSelect.subscribe('onElementSelect', onElementSelect) instead
- * @property {DSCallback} [onElementUnselect] Deprecated: please use DragSelect.subscribe('onElementUnselect', onElementUnselect) instead
  */
 
 /**
@@ -39,6 +33,7 @@
  * @property {boolean} [isDragging] Whether the interaction is a drag or a select
  * @property {boolean} [isDraggingKeyboard] Whether or not the drag interaction is via keyboard
  * @property {string} [key] Pressed key (lowercase)
+ * @property {Settings} [settings] the settings being updates/manipulated/passed, also holds the previous value. i.e. updating selectorClass will publish { settings: { selectorClass: 'newVal', 'selectorClass:pre': 'oldVal' } }
  * @property {Array.<'top'|'bottom'|'left'|'right'|undefined>} [scroll_directions]
  * @property {number} [scroll_multiplier]
  */
@@ -62,7 +57,9 @@
 /** @typedef {'dragmove'|'autoscroll'|'dragstart'|'elementselect'|'elementunselect'|'callback'} DSEventNames */
 /** @typedef {'Interaction:init'|'Interaction:start'|'Interaction:end'|'Interaction:update'|'Area:modified'|'Area:scroll'|'PointerStore:updated'|'Selected:added'|'Selected:removed'|'Selectable:click'|'Selectable:pointer'|'KeyStore:down'|'KeyStore:up'} DSInternalEventNames */
 /** @typedef {'Interaction:init:pre'|'Interaction:start:pre'|'Interaction:end:pre'|'Interaction:update:pre'|'Area:modified:pre'|'Area:scroll:pre'|'PointerStore:updated:pre'|'Selected:added:pre'|'Selected:removed:pre'|'Selectable:click:pre'|'Selectable:pointer:pre'|'KeyStore:down:pre'|'KeyStore:up:pre'} DSInternalEventNamesPre */
-/** @typedef {DSEventNames|DSInternalEventNames|DSInternalEventNamesPre} DSCallbackNames the name of the callback */
+// @todo: update to typescript for complex defs like `Settings:updated:${string}` | `Settings:updated:${string}:pre`
+/** @typedef {'Settings:updated'|'Settings:updated:pre'|'Settings:updated:*'|'Settings:updated:*:pre'} DSInternalSettingEvents */
+/** @typedef {DSEventNames|DSInternalEventNames|DSInternalEventNamesPre|DSInternalSettingEvents} DSCallbackNames the name of the callback */
 
 /** @typedef {{top:number,left:number,bottom:number,right:number,width:number,height:number}} DSBoundingRect */
 /** @typedef {{up:string[],down:string[],left:string[],right:string[]}} DSDragKeys */


### PR DESCRIPTION
This PR solves #111 and #95 and potentially many more!
It adds a settings store and enables settings to be updated dynamically at any time!

So one can for example, update the area like so:
```JavaScript
const ds = new DragSelect({ area: document.getElementById("area") })
ds.setSettings({ area: document.getElementById("new-area") })
```

Basically **_any_** of the [constructor props](https://github.com/ThibaultJanBeyer/DragSelect#constructor-properties) can be updated.

🥂 