### PR TITLE
fix missing inside class

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,11 @@ module.exports = {
     'prettier/prettier': 'error',
     'no-extra-parens': 'off',
     'no-mixed-operators': 'off',
+    'no-underscore-dangle': 'off',
+    'no-return-assign': 'off',
+    'no-unused-vars': 'off',
+    'consistent-return': 'off',
+    'no-plusplus': 'off',
   },
   env: {
     'jest/globals': true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.5.1
+
+- Fix: when an item had multiple dropzones, the `${droppedInsideClass}` was removed even tho’ the item was dropped inside a zone
+
 # 2.5.0
 
 - Add dropZones! Solves #115

--- a/__tests__/functional/dropzone.html
+++ b/__tests__/functional/dropzone.html
@@ -50,6 +50,17 @@
     .ds-dropzone-target {
         background: gold;
     }
+    .ds-dropped-target::before {
+    content: 'dropped';
+    position: absolute;
+    bottom: 0;
+    }
+    .ds-dropped-inside::after {
+    content: 'inside';
+    position: absolute;
+    top: 0;
+    }
+
 </style>
 <script src="../../dist/DragSelect.js"></script>
 <p>Draggable</p>

--- a/__tests__/functional/dropzone.spec.js
+++ b/__tests__/functional/dropzone.spec.js
@@ -45,8 +45,11 @@ describe('DropZone', () => {
     expect(response.dropTarget.itemsDropped[0]).toBe('item-1')
     expect(response.dropTarget.itemsDropped[1]).toBe('item-4')
     expect(response.dropTarget.itemsInside.length).toBe(0)
-    
-    response = await page.evaluate(() => ({ inside: ds.getItemsInsideByZoneId('zone-2').map(item => item.id), dropped: ds.getItemsDroppedByZoneId('zone-2').map(item => item.id) }))
+
+    response = await page.evaluate(() => ({
+      inside: ds.getItemsInsideByZoneId('zone-2').map((item) => item.id),
+      dropped: ds.getItemsDroppedByZoneId('zone-2').map((item) => item.id),
+    }))
     expect(response.inside.length).toBe(2)
     expect(response.inside[0]).toBe('item-2')
     expect(response.inside[1]).toBe('item-4')
@@ -56,7 +59,9 @@ describe('DropZone', () => {
   it('drop inside threshold should be changeable', async () => {
     await page.goto(`${baseUrl}/dropzone.html`)
 
-    response = await page.evaluate(() => { ds.setSettings({ dropInsideThreshold: 0 }) })
+    response = await page.evaluate(() => {
+      ds.setSettings({ dropInsideThreshold: 0 })
+    })
     await moveSelectTo(page, 10, 60, 255, 275)
     response = await page.evaluate(() => ({ dropTarget }))
     expect(response.dropTarget.itemsDropped.length).toBe(1)
@@ -66,12 +71,14 @@ describe('DropZone', () => {
   it('drop target threshold should be changeable', async () => {
     await page.goto(`${baseUrl}/dropzone.html`)
 
-    response = await page.evaluate(() => { ds.setSettings({ dropTargetThreshold: 0.5 }) })
+    response = await page.evaluate(() => {
+      ds.setSettings({ dropTargetThreshold: 0.5 })
+    })
     await moveSelectTo(page, 10, 60, 200, 250)
     response = await page.evaluate(() => ({
       dropTarget,
-      inside: ds.getItemsInsideByZoneId('zone-1').map(item => item.id),
-      dropped: ds.getItemsDroppedByZoneId('zone-1').map(item => item.id)
+      inside: ds.getItemsInsideByZoneId('zone-1').map((item) => item.id),
+      dropped: ds.getItemsDroppedByZoneId('zone-1').map((item) => item.id),
     }))
     expect(response.dropTarget).toMatchObject({})
     expect(response.inside.length).toBe(1)
@@ -96,20 +103,31 @@ describe('DropZone', () => {
     })
     await wait(500)
 
-    const getClasses = async () => page.evaluate(() => ({
-      dropZoneClass: document.querySelectorAll('.dropZoneClass').length,
+    const getClasses = async () =>
+      page.evaluate(() => ({
+        dropZoneClass: document.querySelectorAll('.dropZoneClass').length,
 
-      droppableClass: document.querySelectorAll('.droppableClass').length,
-      droppableClassId2: document.querySelectorAll('.droppableClass-zone-2').length,
-      dropZoneReadyClass: document.querySelectorAll('.dropZoneReadyClass').length,
+        droppableClass: document.querySelectorAll('.droppableClass').length,
+        droppableClassId2: document.querySelectorAll('.droppableClass-zone-2')
+          .length,
+        dropZoneReadyClass: document.querySelectorAll('.dropZoneReadyClass')
+          .length,
 
-      droppedTargetClass: document.querySelectorAll('.droppedTargetClass').length,
-      droppedTargetClassId2: document.querySelectorAll('.droppedTargetClass-zone-2').length,
-      droppedInsideClass: document.querySelectorAll('.droppedInsideClass').length,
-      droppedInsideClassId2: document.querySelectorAll('.droppedInsideClass-zone-2').length,
-      dropZoneTargetClass: document.querySelectorAll('.dropZoneTargetClass').length,
-      dropZoneInsideClass: document.querySelectorAll('.dropZoneInsideClass').length,
-    }))
+        droppedTargetClass: document.querySelectorAll('.droppedTargetClass')
+          .length,
+        droppedTargetClassId2: document.querySelectorAll(
+          '.droppedTargetClass-zone-2'
+        ).length,
+        droppedInsideClass: document.querySelectorAll('.droppedInsideClass')
+          .length,
+        droppedInsideClassId2: document.querySelectorAll(
+          '.droppedInsideClass-zone-2'
+        ).length,
+        dropZoneTargetClass: document.querySelectorAll('.dropZoneTargetClass')
+          .length,
+        dropZoneInsideClass: document.querySelectorAll('.dropZoneInsideClass')
+          .length,
+      }))
 
     // idle
     response = await getClasses()

--- a/src/modules/DropZone.js
+++ b/src/modules/DropZone.js
@@ -2,46 +2,60 @@
 import '../types'
 import DragSelect from '../DragSelect'
 
-import { isCollision, toArray, debounce, addModificationObservers, getAllParentNodes } from '../methods'
+import {
+  isCollision,
+  toArray,
+  debounce,
+  addModificationObservers,
+  getAllParentNodes,
+} from '../methods'
 
 export default class DropZone {
   /**
    * @type {string}
    */
   id
+
   /**
    * @type {DSElement}
    */
   element
+
   /**
    * @type {DSElements}
    */
   droppables
+
   /**
    * @type {DOMRect}
    * @private
    */
   _rect
+
   /**
    * @type {{cleanup:()=>void}}
    * @private
    */
   _observers
+
   /**
    * @type {NodeJS.Timeout}
    * @private
    */
   _timeout
+
   /**
    * @type {DSElements}
    * @private
    */
   _itemsDropped = []
+
   /**
    * @type {DSElements}
    * @private
    */
   _itemsInside
+
   /**
    * @constructor Drag
    * @param {Object} obj
@@ -63,12 +77,12 @@ export default class DropZone {
     // @ts-ignore: @todo: update to typescript
     this.DS.subscribe('Settings:updated:dropZoneClass', ({ settings }) => {
       this.element.classList.remove(settings['dropZoneClass:pre'])
-      this.element.classList.add(settings['dropZoneClass'])
+      this.element.classList.add(settings.dropZoneClass)
     })
 
     this._observers = addModificationObservers(
       this.parentNodes,
-      debounce(() => this._rect = null, this.Settings.refreshMemoryRate),
+      debounce(() => (this._rect = null), this.Settings.refreshMemoryRate)
     )
 
     this.DS.subscribe('Interaction:start', this.start)
@@ -79,8 +93,10 @@ export default class DropZone {
    * @param {'add'|'remove'} action
    */
   setReadyClasses = (action) => {
-    if(this.isDestroyed) return
-    const selectedEls = this.droppables.filter((el) => this.DS.SelectedSet.has(el))
+    if (this.isDestroyed) return
+    const selectedEls = this.droppables.filter((el) =>
+      this.DS.SelectedSet.has(el)
+    )
     if (!selectedEls.length) return
     selectedEls.forEach((item) => {
       item.classList[action](`${this.Settings.droppableClass}`)
@@ -93,16 +109,18 @@ export default class DropZone {
    * This zone is NOT the target of a drop
    */
   handleNoDrop = () => {
-    if(this.isDestroyed) return
+    if (this.isDestroyed) return
     // for each selected element that is not part of the target zone, remove the classes
     this.DS.SelectedSet.forEach((item) => {
       item.classList.remove(this.Settings.droppedTargetClass)
       item.classList.remove(`${this.Settings.droppedTargetClass}-${this.id}`)
     })
     // and remove them from the zones dropped items
-    this._itemsDropped = this._itemsDropped.filter((item) => !this.DS.SelectedSet.has(item))
+    this._itemsDropped = this._itemsDropped.filter(
+      (item) => !this.DS.SelectedSet.has(item)
+    )
     // if the zone has no dropped left, also remove the zones class
-    if(!this._itemsDropped?.length)
+    if (!this._itemsDropped?.length)
       this.element.classList.remove(`${this.Settings.dropZoneTargetClass}`)
   }
 
@@ -110,16 +128,21 @@ export default class DropZone {
    * This zone IS the target of a drop
    */
   handleDrop = () => {
-    if(this.isDestroyed) return
-    // @ts-ignore
-    this._itemsDropped = [...new Set([...this._itemsDropped, ...this.droppables?.filter((item) => this.DS.SelectedSet.has(item))])]
+    if (this.isDestroyed) return
+    this._itemsDropped = [
+      // @ts-ignore
+      ...new Set([
+        ...this._itemsDropped,
+        ...this.droppables?.filter((item) => this.DS.SelectedSet.has(item)),
+      ]),
+    ]
     // add the target class to the zones dropped items
     this._itemsDropped?.forEach((item) => {
       item.classList.add(`${this.Settings.droppedTargetClass}`)
       item.classList.add(`${this.Settings.droppedTargetClass}-${this.id}`)
     })
     // if the zone has dropped, add the zones class
-    if(this._itemsDropped?.length)
+    if (this._itemsDropped?.length)
       this.element.classList.add(`${this.Settings.dropZoneTargetClass}`)
   }
 
@@ -131,15 +154,15 @@ export default class DropZone {
         item.classList.add(`${this.Settings.droppedInsideClass}-${this.id}`)
         isAnyInside = true
       } else {
-        item.classList.remove(`${this.Settings.droppedInsideClass}`)
         item.classList.remove(`${this.Settings.droppedInsideClass}-${this.id}`)
+        if (!item.className.includes(`${this.Settings.droppedInsideClass}-`))
+          item.classList.remove(`${this.Settings.droppedInsideClass}`)
       }
     })
 
     if (isAnyInside)
       this.element.classList.add(`${this.Settings.dropZoneInsideClass}`)
-    else
-      this.element.classList.remove(`${this.Settings.dropZoneInsideClass}`)
+    else this.element.classList.remove(`${this.Settings.dropZoneInsideClass}`)
   }
 
   start = ({ isDragging }) => {
@@ -192,7 +215,7 @@ export default class DropZone {
   }
 
   get itemsDropped() {
-    if(this.isDestroyed) return null
+    if (this.isDestroyed) return null
     return this._itemsDropped
   }
 
@@ -201,18 +224,23 @@ export default class DropZone {
     if (this._itemsInside) return this._itemsInside
 
     this._itemsInside = this.droppables.flatMap((item) => {
-      if(isCollision(
-        this.DS.SelectableSet.rects.get(item),
-        this.rect,
-        this.Settings.dropInsideThreshold
-      ))
+      if (
+        isCollision(
+          this.DS.SelectableSet.rects.get(item),
+          this.rect,
+          this.Settings.dropInsideThreshold
+        )
+      )
         return [item]
       return []
     })
 
     // since elements can be moved while this getter is called, we need to update the values every X seconds
     if (this._timeout) clearTimeout(this._timeout)
-    this._timeout = setTimeout(() => this._itemsInside = null, this.Settings.refreshMemoryRate)
+    this._timeout = setTimeout(
+      () => (this._itemsInside = null),
+      this.Settings.refreshMemoryRate
+    )
 
     return this._itemsInside
   }

--- a/src/modules/DropZones.js
+++ b/src/modules/DropZones.js
@@ -13,18 +13,21 @@ export default class DropZones {
    * @private
    */
   _zoneByElement = new Map()
+
   /**
    * Get the drop zone by the zone id
    * @type {Map<string, DropZone>}
    * @private
    */
   _zoneById = new Map()
+
   /**
    * Get the drop zones by one zone item
    * @type {Map<DSElement,DropZone[]>}
    * @private
    */
   _zonesByDroppable = new Map()
+
   /**
    * Get the drop zones by one zone item
    * @type {DropZone[]}
@@ -43,9 +46,11 @@ export default class DropZones {
 
     // @ts-ignore: @todo: update to typescript
     this.DS.subscribe('Settings:updated:dropZones', this.setDropZones)
-    this.setDropZones({ dropZones: /** @type {DSDropZone[]} */(this.DS.stores.SettingsStore.s.dropZones) })
+    this.setDropZones({
+      dropZones: /** @type {DSDropZone[]} */ (this.DS.stores.SettingsStore.s
+        .dropZones),
+    })
 
-    this.DS.subscribe('Interaction:start', this.start)
     this.DS.subscribe('Interaction:end', this.stop)
   }
 
@@ -57,7 +62,9 @@ export default class DropZones {
     if (!dropZones) return
     if (this._zones) this._zones.forEach((zone) => zone.destroy())
 
-    this._zones = dropZones.map((zone) => new DropZone({ DS: this.DS, ...zone }))
+    this._zones = dropZones.map(
+      (zone) => new DropZone({ DS: this.DS, ...zone })
+    )
     this._zones.forEach((zone) => {
       this._zoneByElement.set(zone.element, zone)
       this._zoneById.set(zone.id, zone)
@@ -85,7 +92,7 @@ export default class DropZones {
    * @returns {DropZone|undefined}
    */
   _getZoneByElementsFromPoint = (elements, { x, y }) => {
-    for(let i = 0, il = elements.length; i < il; i++) {
+    for (let i = 0, il = elements.length; i < il; i++) {
       const zone = this._zoneByElement.get(elements[i])
       if (
         zone &&
@@ -100,21 +107,17 @@ export default class DropZones {
     }
   }
 
-  start = ({ isDragging }) => {
-    if (!isDragging) return
-  }
-
   stop = ({ isDragging }) => {
     if (!isDragging) return
     const target = this.getTarget()
     this._handleDrop(target)
   }
 
-  //////////////////////////////////////////////////////////////////////////////////////
+  /// ///////////////////////////////////////////////////////////////////////////////////
   // Getters
 
   /**
-   * @param {string} zoneId 
+   * @param {string} zoneId
    * @returns {DSElements|void}
    */
   getItemsDroppedById = (zoneId) => {
@@ -124,15 +127,15 @@ export default class DropZones {
   }
 
   /**
-   * @param {string} zoneId 
+   * @param {string} zoneId
    * @param {boolean} addClasses
    * @returns {DSElements|void}
    */
   getItemsInsideById = (zoneId, addClasses) => {
     const zone = this._zoneById.get(zoneId)
     if (!zone) return console.warn(`[DragSelect] No zone found (id: ${zoneId})`)
-    const itemsInside = zone.itemsInside
-    if(addClasses) zone.handleItemsInsideClasses()
+    const { itemsInside } = zone
+    if (addClasses) zone.handleItemsInsideClasses()
     return itemsInside
   }
 
@@ -143,11 +146,14 @@ export default class DropZones {
    */
   getTarget = (coordinates) => {
     if (!this._zones?.length) return
-    
+
     const x = coordinates?.x || this.DS.stores.PointerStore.currentVal.x
     const y = coordinates?.y || this.DS.stores.PointerStore.currentVal.y
-    
+
     const elements = document.elementsFromPoint(x, y)
-    return this._getZoneByElementsFromPoint(/** @type {DSElements} */(elements), { x, y })
+    return this._getZoneByElementsFromPoint(
+      /** @type {DSElements} */ (elements),
+      { x, y }
+    )
   }
 }


### PR DESCRIPTION
Fix: when an item had multiple dropzones, the `${droppedInsideClass}` was removed even tho’ the item was dropped inside a zone