### PR TITLE
Feature/control draggability of individual points

### DIFF
--- a/DragSelect/src/DragSelect.js
+++ b/DragSelect/src/DragSelect.js
@@ -377,6 +377,27 @@ class DragSelect {
    */
   getItemsInsideByZoneId = (zoneId, addClasses) =>
     this.DropZones.getItemsInsideById(zoneId, addClasses)
+
+  /**
+   * Make element draggable
+   * @param {DSElement} element
+   * @returns {Boolean} whether the element can be dragged
+   */
+  canBeDragged = (element) => this.SelectableSet.canBeDragged(element)
+
+  /**
+   * Make element draggable
+   * @param {DSElement} element
+   * @returns {void}
+   */
+  makeDraggable = (element) => this.SelectableSet.makeDraggable(element)
+
+  /**
+   * Make element non-draggable
+   * @param {DSElement} element
+   * @returns {void}
+   */
+  makeNonDraggable = (element) => this.SelectableSet.makeNonDraggable(element)
 }
 
 export default DragSelect

--- a/DragSelect/src/methods/hydrateSettings.js
+++ b/DragSelect/src/methods/hydrateSettings.js
@@ -252,4 +252,5 @@ export default (settings, withFallback) => ({
     withFallback,
     'ds-dropzone-inside'
   ),
+  ...hydrateHelper('noDragClass', settings.noDragClass, withFallback, 'ds-no-drag'),
 })

--- a/DragSelect/src/modules/Drag.js
+++ b/DragSelect/src/modules/Drag.js
@@ -108,14 +108,15 @@ export default class Drag {
       dragKeys: this._dragKeys,
     })
 
-    this._elements.forEach((element) =>
+    this._elements.forEach((element) => {
+      if (!this.DS.SelectableSet.canBeDragged(element)) return
       moveElement({
         element,
         posDirection,
         containerRect: this.DS.SelectorArea.rect,
         useTransform: this.DS.stores.SettingsStore.s.useTransform,
       })
-    )
+    })
 
     this.DS.publish(
       ['Interaction:update:pre', 'Interaction:update'],
@@ -167,14 +168,15 @@ export default class Drag {
 
     const posDirection = vect2.calc(this._cursorDiff, '+', this._scrollDiff)
 
-    this._elements.forEach((element) =>
+    this._elements.forEach((element) => {
+      if (!this.DS.SelectableSet.canBeDragged(element)) return
       moveElement({
         element,
         posDirection,
         containerRect: this.DS.SelectorArea.rect,
         useTransform: this.DS.stores.SettingsStore.s.useTransform,
       })
-    )
+    })
   }
 
   handleZIndex = (add) => {

--- a/DragSelect/src/modules/SelectableSet.js
+++ b/DragSelect/src/modules/SelectableSet.js
@@ -117,6 +117,19 @@ export default class SelectableSet extends Set {
   /** @param {DSElements} elements */
   deleteAll = (elements) => elements.forEach((el) => this.delete(el))
 
+  /** @param {DSElement} element */
+  /** @return {Boolean} whether the element can be dragged */
+  canBeDragged = (element) =>
+    !element.classList.contains(this.DS.stores.SettingsStore.s.noDragClass)
+
+  /** @param {DSElement} element */
+  makeDraggable = (element) =>
+    element.classList.remove(this.DS.stores.SettingsStore.s.noDragClass)
+
+  /** @param {DSElement} element */
+  makeNonDraggable = (element) =>
+    element.classList.add(this.DS.stores.SettingsStore.s.noDragClass)
+
   /** @return {DSElements} */
   get elements() {
     return Array.from(this.values())

--- a/DragSelect/src/types.js
+++ b/DragSelect/src/types.js
@@ -35,6 +35,7 @@
  * @property {string} [dropZoneReadyClass=ds-dropzone-ready] on corresponding dropZone when element is dragged
  * @property {string} [dropZoneTargetClass=ds-dropzone-target] on dropZone that has elements from any successful target drop
  * @property {string} [dropZoneInsideClass=ds-dropzone-inside] on dropZone that has elements inside after any drop
+ * @property {string} [noDragClass=ds-no-drag] the class assigned to a non-draggable element
  */
 
 /**

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Here is the full list:
 |dropZoneReadyClass |string |On corresponding dropZone when element is dragged |ds-dropzone-ready
 |dropZoneTargetClass |string |On dropZone that has elements from any successful target drop |ds-dropzone-target
 |dropZoneInsideClass |string |On dropZone that has elements inside after any drop |ds-dropzone-inside
+|noDragClass |string |The class assigned to a non-draggable element |ds-no-drag
 
 ## Post-Initialization Setting-Updates
 
@@ -397,6 +398,9 @@ Read the [Methods API docs](http://dragselect.com/docs/API/Methods)
 |getZoneByCoordinates |Optional `{x: number, y: number}` |Returns the first drop target under the current mouse position, or, if provided at coordinates x/y
 |getItemsDroppedByZoneId |`zoneId: string` |Returns the items dropped into a specific zone (by zone.id)
 |getItemsInsideByZoneId |`zoneId: string`,`addClasses: boolean` |Returns the items that are visually inside a specific zone (by zone.id)
+|canBeDragged |`element:DOM Element` |Whether the element can be dragged
+|makeDraggable |`element:DOM Element` |Make element draggable
+|makeNonDraggable |`element:DOM Element` |Make element non-draggable
 
 # CSS Classes
 
@@ -419,6 +423,7 @@ Read the [CSS Classes API docs](http://dragselect.com/docs/API/CSS-Classes)
 |.ds-dropzone-ready |on corresponding dropZone when corresponding item is being dragged |
 |.ds-dropzone-target |on dropZone when it was target of a successful drop |
 |.ds-dropzone-inside |on dropZone that has elements inside after any drop |
+|.ds-no-drag |On items that cannot be dragged |
 
 *note: you can change the class names setting the respective property on the constructor, see **[the docs](http://dragselect.com/docs/API/Settings)** properties section.*
 


### PR DESCRIPTION
**User story**:
As a user I want to have control over the draggability of particular set of selected points without modifying the initial selection.

**Description**:
This PR exposes additional API for the developer to change the draggability option for a set of particular points.
- `canBeDragged(element)`: checks whether the element can be dragged.
- `makeDraggable(element)`: make element draggable.
- `makeNonDraggable(element)`: make element non-draggable.

**Usage example**:
```javascript
const ds = new DragSelect({
  selectables: document.getElementsByClassName('item'),
  area: document.getElementById('container'),
  draggability: true, // optional, but has to be set 'true' to control draggability of individual points
  noDragClass: 'no-drag', // optional, defaults to 'ds-no-drag'
});

// Make every other element non-draggable
ds.subscribe('predragstart', (data) => {
  if (data.isDragging) {
    data.items.forEach((item, index) => {
      index % 2 === 0 // index is even
        ? ds.makeDraggable(item)
        : ds.makeNonDraggable(item);
    });
  }
});
```