### PR TITLE
setSettings/dropZone crash bug:

### DIFF
--- a/DragSelect/src/modules/DropZone.js
+++ b/DragSelect/src/modules/DropZone.js
@@ -76,6 +76,7 @@ export default class DropZone {
 
     // @ts-ignore: @todo: update to typescript
     this.DS.subscribe('Settings:updated:dropZoneClass', ({ settings }) => {
+      if (!this.element) return
       this.element.classList.remove(settings['dropZoneClass:pre'])
       this.element.classList.add(settings.dropZoneClass)
     })


### PR DESCRIPTION
Calling _setSettings_ with properties _dropZoneClass_ and _dropZones_ simultaneously resulted in crash due to trying to access _this.element.classList_ when _this.element_ is undefined. Solved by early return if _this.element_ is falsy.