### PR TITLE
Fix for selection area being faulty if any ancestor node has been scrolled.

### DIFF
--- a/DragSelect/src/modules/Interaction.js
+++ b/DragSelect/src/modules/Interaction.js
@@ -78,11 +78,14 @@ export default class Interaction {
   /**
    * @param {DSEvent} event
    */
-  start = (event) =>
+  start = (event) => {
+    this.DS.Area.reset();
+    this.DS.SelectorArea.updatePos();
     this.DS.publish('Interaction:start:pre', {
       event,
       isDragging: this.isDragging,
-    })
+    });
+  }
 
   _start = (event) => {
     if (event.type === 'touchstart') event.preventDefault() // Call preventDefault() to prevent double click issue, see https://github.com/ThibaultJanBeyer/DragSelect/pull/29 & https://developer.mozilla.org/vi/docs/Web/API/Touch_events/Supporting_both_TouchEvent_and_MouseEvent

--- a/DragSelect/src/modules/Interaction.js
+++ b/DragSelect/src/modules/Interaction.js
@@ -79,12 +79,12 @@ export default class Interaction {
    * @param {DSEvent} event
    */
   start = (event) => {
-    this.DS.Area.reset();
-    this.DS.SelectorArea.updatePos();
+    this.DS.Area.reset()
+    this.DS.SelectorArea.updatePos()
     this.DS.publish('Interaction:start:pre', {
       event,
       isDragging: this.isDragging,
-    });
+    })
   }
 
   _start = (event) => {


### PR DESCRIPTION
Interaction: Call _Area.reset_ and _SelectorArea.updatePos_ on _Interaction start_ to make sure selection area is up to date after scrolling any _DragSelect_ _area_ ancestor.

Without fix _DragSelect_ _area_ doesn't align with _area_ node after scrolling ancestor.