### PR TITLE
fix:当使用浏览器的快速填充时，会报错

### DIFF
--- a/DragSelect/src/stores/KeyStore.js
+++ b/DragSelect/src/stores/KeyStore.js
@@ -37,6 +37,7 @@ export default class KeyStore {
 
   /** @param {KeyboardEvent} event */
   keydown = (event) => {
+    if(!event.key) return
     const key = event.key.toLowerCase()
     this.DS.publish('KeyStore:down:pre', { event, key })
     this._currentValues.add(key)
@@ -45,6 +46,7 @@ export default class KeyStore {
 
   /** @param {KeyboardEvent} event */
   keyup = (event) => {
+    if(!event.key) return
     const key = event.key.toLowerCase()
     this.DS.publish('KeyStore:up:pre', { event, key })
     this._currentValues.delete(key)


### PR DESCRIPTION
当使用浏览器的快速填充时，event.key 没有值，会报错
![image](https://github.com/ThibaultJanBeyer/DragSelect/assets/17328227/95d7c58d-4263-4ebc-a16a-069d3c5a0daa)
