### PR TITLE
Update canScroll method to prevent unintended scroll

### DIFF
--- a/DragSelect/__tests__/functional/scroll.spec.js
+++ b/DragSelect/__tests__/functional/scroll.spec.js
@@ -86,4 +86,37 @@ describe('Scroll', () => {
     selection = await page.evaluate(() => ds.getSelection())
     expect(selection.length).toBe(1)
   })
+
+  it('clicking in scrollable area should not cause scroll to occur', async () => {
+    await page.goto(`${baseUrl}/scroll.html`)
+
+    const areaHandle = await page.$('#lel')
+
+    const { areaTop, areaLeft, areaWidth, areaHeight, areaScrollTop } = await page.evaluate(area => {
+      return {
+        areaTop: area.offsetTop,
+        areaLeft: area.offsetLeft,
+        areaWidth: area.offsetWidth,
+        areaHeight: area.offsetHeight,
+        areaScrollTop: area.scrollTop
+      }
+    }, areaHandle)
+
+    expect(areaScrollTop).toBe(0)
+
+    // Calculate middle of scrollable area and click
+    const areaMidX = (areaWidth / 2) + areaLeft
+    const areaMidY = (areaHeight / 2) + areaTop
+
+    const mouse = page.mouse
+    await mouse.move(areaMidX, areaMidY)
+    await mouse.down()
+    await mouse.up()
+
+    const updatedAreaScrollTop = await page.evaluate(area => area.scrollTop, areaHandle)
+
+    expect(updatedAreaScrollTop).toBe(0)
+
+    await areaHandle.dispose()
+  })
 })

--- a/DragSelect/src/methods/canScroll.ts
+++ b/DragSelect/src/methods/canScroll.ts
@@ -11,9 +11,17 @@ export const canScroll: CanScroll = area => {
   if (scroll.x || scroll.y) return true
 
   if (area instanceof Document) {
-    if (area.body) return Boolean(area.body.scrollTop = 1)
-    return Boolean(area.documentElement.scrollTop = 1)
+    if (area.body) return _canScroll(area.body)
+    return _canScroll(area.documentElement)
   }
 
-  return Boolean(area.scrollTop = 1)
+  return _canScroll(area)
+}
+
+// @TODO: Determine if there is a better way to test scrollability
+const _canScroll = (el: Element): boolean => {
+  const currentScrollTop = el.scrollTop
+  const canScroll = Boolean(el.scrollTop = 1)
+  el.scrollTop = currentScrollTop
+  return canScroll
 }


### PR DESCRIPTION
The canScroll method was updated to restore the area's original scrollTop value after determining scrollability. A simple test case was added to prevent future regressions.

Fixes #208 